### PR TITLE
Add AdvertiseAddr / AdvertisePort functionality

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,7 +15,12 @@ type Config struct {
 	// It is assumed other nodes are running on this port, but they
 	// do not need to.
 	BindAddr string
-	Port     int
+	BindPort int
+
+	// Configuration related to what address to advertise to other
+	// cluster members. Used for nat traversal.
+	AdvertiseAddr string
+	AdvertisePort int
 
 	// ProtocolVersion is the configured protocol version that we
 	// will _speak_. This must be between ProtocolVersionMin and
@@ -135,7 +140,9 @@ func DefaultLANConfig() *Config {
 	return &Config{
 		Name:             hostname,
 		BindAddr:         "0.0.0.0",
-		Port:             7946,
+		BindPort:         7946,
+		AdvertiseAddr:    "",
+		AdvertisePort:    7946,
 		ProtocolVersion:  ProtocolVersionMax,
 		TCPTimeout:       10 * time.Second,       // Timeout after 10 seconds
 		IndirectChecks:   3,                      // Use 3 nodes for the indirect ping

--- a/integ_test.go
+++ b/integ_test.go
@@ -36,7 +36,7 @@ func TestMemberlist_Integ(t *testing.T) {
 		c := DefaultLANConfig()
 		c.Name = fmt.Sprintf("%s:%d", addr, 12345+i)
 		c.BindAddr = addr
-		c.Port = 12345 + i
+		c.BindPort = 12345 + i
 		c.ProbeInterval = 10 * time.Millisecond
 		c.ProbeTimeout = 100 * time.Millisecond
 		c.GossipInterval = 5 * time.Millisecond

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -79,7 +79,7 @@ func GetMemberlistDelegate(t *testing.T) (*Memberlist, *MockDelegate) {
 		if err == nil {
 			return m, d
 		}
-		c.Port++
+		c.BindPort++
 	}
 	t.Fatalf("failed to start: %v", err)
 	return nil, nil
@@ -95,7 +95,7 @@ func GetMemberlist(t *testing.T) *Memberlist {
 		if err == nil {
 			return m
 		}
-		c.Port++
+		c.BindPort++
 	}
 	t.Fatalf("failed to start: %v", err)
 	return nil
@@ -263,7 +263,7 @@ func TestMemberlist_Join(t *testing.T) {
 	addr1 := getBindAddr()
 	c.Name = addr1.String()
 	c.BindAddr = addr1.String()
-	c.Port = m1.config.Port
+	c.BindPort = m1.config.BindPort
 
 	m2, err := Create(c)
 	if err != nil {
@@ -333,7 +333,7 @@ func TestMemberlist_Leave(t *testing.T) {
 	addr1 := getBindAddr()
 	c.Name = addr1.String()
 	c.BindAddr = addr1.String()
-	c.Port = m1.config.Port
+	c.BindPort = m1.config.BindPort
 	c.GossipInterval = time.Millisecond
 
 	m2, err := Create(c)
@@ -384,7 +384,7 @@ func TestMemberlist_JoinShutdown(t *testing.T) {
 	addr1 := getBindAddr()
 	c.Name = addr1.String()
 	c.BindAddr = addr1.String()
-	c.Port = m1.config.Port
+	c.BindPort = m1.config.BindPort
 	c.ProbeInterval = time.Millisecond
 	c.ProbeTimeout = 100 * time.Microsecond
 
@@ -502,7 +502,7 @@ func TestMemberlist_UserData(t *testing.T) {
 	addr1 := getBindAddr()
 	c.Name = addr1.String()
 	c.BindAddr = addr1.String()
-	c.Port = m1.config.Port
+	c.BindPort = m1.config.BindPort
 	c.GossipInterval = time.Millisecond
 	c.PushPullInterval = time.Millisecond
 	c.Delegate = d2
@@ -574,7 +574,7 @@ func TestMemberlist_Join_DeadNode(t *testing.T) {
 	// Create a second "node", which is just a TCP listener that
 	// does not ever respond. This is to test our deadliens
 	addr1 := getBindAddr()
-	list, err := net.Listen("tcp", fmt.Sprintf("%s:%d", addr1.String(), m1.config.Port))
+	list, err := net.Listen("tcp", fmt.Sprintf("%s:%d", addr1.String(), m1.config.BindPort))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -610,7 +610,7 @@ func TestMemberlist_Join_Proto1And2(t *testing.T) {
 	addr1 := getBindAddr()
 	c.Name = addr1.String()
 	c.BindAddr = addr1.String()
-	c.Port = m1.config.Port
+	c.BindPort = m1.config.BindPort
 	c.ProtocolVersion = 1
 
 	m2, err := Create(c)
@@ -645,7 +645,7 @@ func TestMemberlist_Join_IPv6(t *testing.T) {
 	var m1 *Memberlist
 	var err error
 	for i := 0; i < 100; i++ {
-		c1.Port = 23456 + i
+		c1.BindPort = 23456 + i
 		m1, err = Create(c1)
 		if err == nil {
 			break
@@ -662,7 +662,7 @@ func TestMemberlist_Join_IPv6(t *testing.T) {
 	c2.BindAddr = "[::1]"
 	var m2 *Memberlist
 	for i := 0; i < 100; i++ {
-		c2.Port = c1.Port + 1 + i
+		c2.BindPort = c1.BindPort + 1 + i
 		m2, err = Create(c2)
 		if err == nil {
 			break

--- a/net.go
+++ b/net.go
@@ -330,7 +330,7 @@ func (m *Memberlist) handleIndirectPing(buf []byte, from net.Addr) {
 	// For proto versions < 2, there is no port provided. Mask old
 	// behavior by using the configured port
 	if m.ProtocolVersion() < 2 || ind.Port == 0 {
-		ind.Port = uint16(m.config.Port)
+		ind.Port = uint16(m.config.BindPort)
 	}
 
 	// Send a ping to the correct host
@@ -381,7 +381,7 @@ func (m *Memberlist) handleAlive(buf []byte, from net.Addr) {
 	// For proto versions < 2, there is no port provided. Mask old
 	// behavior by using the configured port
 	if m.ProtocolVersion() < 2 || live.Port == 0 {
-		live.Port = uint16(m.config.Port)
+		live.Port = uint16(m.config.BindPort)
 	}
 
 	m.aliveNode(&live)
@@ -754,7 +754,7 @@ func (m *Memberlist) readRemoteState(conn net.Conn) (bool, []pushNodeState, []by
 	// behavior by using the configured port
 	for idx := range remoteNodes {
 		if m.ProtocolVersion() < 2 || remoteNodes[idx].Port == 0 {
-			remoteNodes[idx].Port = uint16(m.config.Port)
+			remoteNodes[idx].Port = uint16(m.config.BindPort)
 		}
 	}
 

--- a/net_test.go
+++ b/net_test.go
@@ -42,7 +42,7 @@ func TestHandleCompoundPing(t *testing.T) {
 	compound := makeCompoundMessage([][]byte{buf.Bytes(), buf.Bytes(), buf.Bytes()})
 
 	// Send compound version
-	addr := &net.UDPAddr{IP: net.ParseIP(m.config.BindAddr), Port: m.config.Port}
+	addr := &net.UDPAddr{IP: net.ParseIP(m.config.BindAddr), Port: m.config.BindPort}
 	udp.WriteTo(compound.Bytes(), addr)
 
 	// Wait for responses
@@ -102,7 +102,7 @@ func TestHandlePing(t *testing.T) {
 	}
 
 	// Send
-	addr := &net.UDPAddr{IP: net.ParseIP(m.config.BindAddr), Port: m.config.Port}
+	addr := &net.UDPAddr{IP: net.ParseIP(m.config.BindAddr), Port: m.config.BindPort}
 	udp.WriteTo(buf.Bytes(), addr)
 
 	// Wait for response
@@ -156,7 +156,7 @@ func TestHandleIndirectPing(t *testing.T) {
 	ind := indirectPingReq{
 		SeqNo:  100,
 		Target: net.ParseIP(m.config.BindAddr),
-		Port:   uint16(m.config.Port),
+		Port:   uint16(m.config.BindPort),
 	}
 	buf, err := encode(indirectPingMsg, &ind)
 	if err != nil {
@@ -164,7 +164,7 @@ func TestHandleIndirectPing(t *testing.T) {
 	}
 
 	// Send
-	addr := &net.UDPAddr{IP: net.ParseIP(m.config.BindAddr), Port: m.config.Port}
+	addr := &net.UDPAddr{IP: net.ParseIP(m.config.BindAddr), Port: m.config.BindPort}
 	udp.WriteTo(buf.Bytes(), addr)
 
 	// Wait for response
@@ -202,14 +202,14 @@ func TestTCPPushPull(t *testing.T) {
 		Node: Node{
 			Name: "Test 0",
 			Addr: net.ParseIP(m.config.BindAddr),
-			Port: uint16(m.config.Port),
+			Port: uint16(m.config.BindPort),
 		},
 		Incarnation: 0,
 		State:       stateSuspect,
 		StateChange: time.Now().Add(-1 * time.Second),
 	})
 
-	addr := fmt.Sprintf("%s:%d", m.config.BindAddr, m.config.Port)
+	addr := fmt.Sprintf("%s:%d", m.config.BindAddr, m.config.BindPort)
 	conn, err := net.Dial("tcp", addr)
 	if err != nil {
 		t.Fatalf("unexpected err %s", err)
@@ -219,17 +219,17 @@ func TestTCPPushPull(t *testing.T) {
 	localNodes := make([]pushNodeState, 3)
 	localNodes[0].Name = "Test 0"
 	localNodes[0].Addr = net.ParseIP(m.config.BindAddr)
-	localNodes[0].Port = uint16(m.config.Port)
+	localNodes[0].Port = uint16(m.config.BindPort)
 	localNodes[0].Incarnation = 1
 	localNodes[0].State = stateAlive
 	localNodes[1].Name = "Test 1"
 	localNodes[1].Addr = net.ParseIP(m.config.BindAddr)
-	localNodes[1].Port = uint16(m.config.Port)
+	localNodes[1].Port = uint16(m.config.BindPort)
 	localNodes[1].Incarnation = 1
 	localNodes[1].State = stateAlive
 	localNodes[2].Name = "Test 2"
 	localNodes[2].Addr = net.ParseIP(m.config.BindAddr)
-	localNodes[2].Port = uint16(m.config.Port)
+	localNodes[2].Port = uint16(m.config.BindPort)
 	localNodes[2].Incarnation = 1
 	localNodes[2].State = stateAlive
 
@@ -350,7 +350,7 @@ func TestSendMsg_Piggyback(t *testing.T) {
 	}
 
 	// Send
-	addr := &net.UDPAddr{IP: net.ParseIP(m.config.BindAddr), Port: m.config.Port}
+	addr := &net.UDPAddr{IP: net.ParseIP(m.config.BindAddr), Port: m.config.BindPort}
 	udp.WriteTo(buf.Bytes(), addr)
 
 	// Wait for response

--- a/state_test.go
+++ b/state_test.go
@@ -34,14 +34,14 @@ func TestMemberList_Probe(t *testing.T) {
 	a1 := alive{
 		Node:        addr1.String(),
 		Addr:        []byte(addr1),
-		Port:        uint16(m1.config.Port),
+		Port:        uint16(m1.config.BindPort),
 		Incarnation: 1,
 	}
 	m1.aliveNode(&a1)
 	a2 := alive{
 		Node:        addr2.String(),
 		Addr:        []byte(addr2),
-		Port:        uint16(m2.config.Port),
+		Port:        uint16(m2.config.BindPort),
 		Incarnation: 1,
 	}
 	m1.aliveNode(&a2)


### PR DESCRIPTION
Adds `AdvertiseAddr` and `AdvertisePort` to allow the advertised address to be different from the bind address.

_Current_ tests are modified so that they pass given the renamed variable (`Port` -> `BindPort`) but other than that, these changes are not explicitly tested (although existing tests should pass) - because honestly I'm not quite sure how to go about testing these.
