### PR TITLE
Standardize 'primary key' in error messages

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -96,7 +96,7 @@ func (k *Keyring) UseKey(key []byte) error {
 // requested for removal is currently at position 0 (primary key).
 func (k *Keyring) RemoveKey(key []byte) error {
 	if bytes.Equal(key, k.keys[0]) {
-		return fmt.Errorf("Removing the active key is not allowed")
+		return fmt.Errorf("Removing the primary key is not allowed")
 	}
 	for i, installedKey := range k.keys {
 		if bytes.Equal(key, installedKey) {

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -68,7 +68,7 @@ func TestKeyring_AddRemoveUse(t *testing.T) {
 
 	keys := keyring.GetKeys()
 	if !bytes.Equal(keys[0], TestKeys[1]) {
-		t.Fatalf("Unexpected active key change")
+		t.Fatalf("Unexpected primary key change")
 	}
 
 	if len(keys) != 2 {


### PR DESCRIPTION
Should have looked closer before submitting my PR, but this just makes sure we call the 'primary key' the same thing in all of our error messages. 'active' seems ambiguous.
