### PR TITLE
Fix: replace ParseInt by ParseUint for parsing ports

### DIFF
--- a/memberlist.go
+++ b/memberlist.go
@@ -194,7 +194,7 @@ func (m *Memberlist) resolveAddr(hostStr string) ([][]byte, uint16, error) {
 	} else if err != nil {
 		// error, but not missing port
 		return ips, port, err
-	} else if lport, err := strconv.ParseInt(sport, 10, 16); err != nil {
+	} else if lport, err := strconv.ParseUint(sport, 10, 16); err != nil {
 		// error, when parsing port
 		return ips, port, err
 	} else {


### PR DESCRIPTION
Port numbers are 16bits, unsigned ints, so parsing them with strconv.ParseInt produced this kind of errors:

```
Failed to join node at 78.203.3.137:33945: strconv.ParseInt: parsing "33945": value out of range
```

I have replaced it by a ParseUint and it solves the problem.
