### PR TITLE
vet fix

### DIFF
--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -339,16 +339,16 @@ func TestMemberlist_Join(t *testing.T) {
 
 	m2, err := Create(c)
 	if err != nil {
-		t.Fatal("unexpected err: %s", err)
+		t.Fatalf("unexpected err: %s", err)
 	}
 	defer m2.Shutdown()
 
 	num, err := m2.Join([]string{m1.config.BindAddr})
 	if num != 1 {
-		t.Fatal("unexpected 1: %d", num)
+		t.Fatalf("unexpected 1: %d", num)
 	}
 	if err != nil {
-		t.Fatal("unexpected err: %s", err)
+		t.Fatalf("unexpected err: %s", err)
 	}
 
 	// Check the hosts
@@ -410,16 +410,16 @@ func TestMemberlist_Leave(t *testing.T) {
 
 	m2, err := Create(c)
 	if err != nil {
-		t.Fatal("unexpected err: %s", err)
+		t.Fatalf("unexpected err: %s", err)
 	}
 	defer m2.Shutdown()
 
 	num, err := m2.Join([]string{m1.config.BindAddr})
 	if num != 1 {
-		t.Fatal("unexpected 1: %d", num)
+		t.Fatalf("unexpected 1: %d", num)
 	}
 	if err != nil {
-		t.Fatal("unexpected err: %s", err)
+		t.Fatalf("unexpected err: %s", err)
 	}
 
 	// Check the hosts
@@ -462,16 +462,16 @@ func TestMemberlist_JoinShutdown(t *testing.T) {
 
 	m2, err := Create(c)
 	if err != nil {
-		t.Fatal("unexpected err: %s", err)
+		t.Fatalf("unexpected err: %s", err)
 	}
 	defer m2.Shutdown()
 
 	num, err := m2.Join([]string{m1.config.BindAddr})
 	if num != 1 {
-		t.Fatal("unexpected 1: %d", num)
+		t.Fatalf("unexpected 1: %d", num)
 	}
 	if err != nil {
-		t.Fatal("unexpected err: %s", err)
+		t.Fatalf("unexpected err: %s", err)
 	}
 
 	// Check the hosts
@@ -658,14 +658,14 @@ func TestMemberlist_UserData(t *testing.T) {
 
 	m2, err := Create(c)
 	if err != nil {
-		t.Fatal("unexpected err: %s", err)
+		t.Fatalf("unexpected err: %s", err)
 	}
 	num, err := m2.Join([]string{m1.config.BindAddr})
 	if num != 1 {
-		t.Fatal("unexpected 1: %d", num)
+		t.Fatalf("unexpected 1: %d", num)
 	}
 	if err != nil {
-		t.Fatal("unexpected err: %s", err)
+		t.Fatalf("unexpected err: %s", err)
 	}
 	defer m2.Shutdown()
 
@@ -718,16 +718,16 @@ func TestMemberlist_SendTo(t *testing.T) {
 
 	m2, err := Create(c)
 	if err != nil {
-		t.Fatal("unexpected err: %s", err)
+		t.Fatalf("unexpected err: %s", err)
 	}
 	defer m2.Shutdown()
 
 	num, err := m2.Join([]string{m1.config.BindAddr})
 	if num != 1 {
-		t.Fatal("unexpected 1: %d", num)
+		t.Fatalf("unexpected 1: %d", num)
 	}
 	if err != nil {
-		t.Fatal("unexpected err: %s", err)
+		t.Fatalf("unexpected err: %s", err)
 	}
 
 	// Check the hosts
@@ -807,7 +807,7 @@ func TestMemberlist_Join_DeadNode(t *testing.T) {
 
 	num, err := m1.Join([]string{addr1.String()})
 	if num != 0 {
-		t.Fatal("unexpected 0: %d", num)
+		t.Fatalf("unexpected 0: %d", num)
 	}
 	if err == nil {
 		t.Fatal("expect err")
@@ -834,16 +834,16 @@ func TestMemberlist_Join_Proto1And2(t *testing.T) {
 
 	m2, err := Create(c)
 	if err != nil {
-		t.Fatal("unexpected err: %s", err)
+		t.Fatalf("unexpected err: %s", err)
 	}
 	defer m2.Shutdown()
 
 	num, err := m2.Join([]string{m1.config.BindAddr})
 	if num != 1 {
-		t.Fatal("unexpected 1: %d", num)
+		t.Fatalf("unexpected 1: %d", num)
 	}
 	if err != nil {
-		t.Fatal("unexpected err: %s", err)
+		t.Fatalf("unexpected err: %s", err)
 	}
 
 	// Check the hosts
@@ -871,7 +871,7 @@ func TestMemberlist_Join_IPv6(t *testing.T) {
 		}
 	}
 	if err != nil {
-		t.Fatal("unexpected err: %s", err)
+		t.Fatalf("unexpected err: %s", err)
 	}
 	defer m1.Shutdown()
 
@@ -888,16 +888,16 @@ func TestMemberlist_Join_IPv6(t *testing.T) {
 		}
 	}
 	if err != nil {
-		t.Fatal("unexpected err: %s", err)
+		t.Fatalf("unexpected err: %s", err)
 	}
 	defer m2.Shutdown()
 
 	num, err := m2.Join([]string{fmt.Sprintf("%s:%d", m1.config.BindAddr, 23456)})
 	if num != 1 {
-		t.Fatal("unexpected 1: %d", num)
+		t.Fatalf("unexpected 1: %d", num)
 	}
 	if err != nil {
-		t.Fatal("unexpected err: %s", err)
+		t.Fatalf("unexpected err: %s", err)
 	}
 
 	// Check the hosts


### PR DESCRIPTION
Fixes the following vet reports:

```
memberlist_test.go:342: possible formatting directive in Fatal call
memberlist_test.go:348: possible formatting directive in Fatal call
memberlist_test.go:351: possible formatting directive in Fatal call
memberlist_test.go:413: possible formatting directive in Fatal call
memberlist_test.go:419: possible formatting directive in Fatal call
memberlist_test.go:422: possible formatting directive in Fatal call
memberlist_test.go:465: possible formatting directive in Fatal call
memberlist_test.go:471: possible formatting directive in Fatal call
memberlist_test.go:474: possible formatting directive in Fatal call
memberlist_test.go:661: possible formatting directive in Fatal call
memberlist_test.go:665: possible formatting directive in Fatal call
memberlist_test.go:668: possible formatting directive in Fatal call
memberlist_test.go:721: possible formatting directive in Fatal call
memberlist_test.go:727: possible formatting directive in Fatal call
memberlist_test.go:730: possible formatting directive in Fatal call
memberlist_test.go:810: possible formatting directive in Fatal call
memberlist_test.go:837: possible formatting directive in Fatal call
memberlist_test.go:843: possible formatting directive in Fatal call
memberlist_test.go:846: possible formatting directive in Fatal call
memberlist_test.go:874: possible formatting directive in Fatal call
memberlist_test.go:891: possible formatting directive in Fatal call
memberlist_test.go:897: possible formatting directive in Fatal call
memberlist_test.go:900: possible formatting directive in Fatal call
```
