### PR TITLE
data race

### DIFF
--- a/memberlist.go
+++ b/memberlist.go
@@ -118,7 +118,11 @@ func newMemberlist(conf *Config) (*Memberlist, error) {
 		broadcasts:     &TransmitLimitedQueue{RetransmitMult: conf.RetransmitMult},
 		logger:         logger,
 	}
-	m.broadcasts.NumNodes = func() int { return len(m.nodes) }
+	m.broadcasts.NumNodes = func() int {
+		m.nodeLock.RLock()
+		defer m.nodeLock.RUnlock()
+		return len(m.nodes)
+	}
 	go m.tcpListen()
 	go m.udpListen()
 	go m.udpHandler()


### PR DESCRIPTION
Ran into this in some automated NSQ tests:

```
==================
WARNING: DATA RACE
Write by goroutine 54:
  github.com/hashicorp/memberlist.(*Memberlist).resetNodes()
      /home/travis/gopath/src/github.com/hashicorp/memberlist/state.go:288 +0x299
  github.com/hashicorp/memberlist.(*Memberlist).probe()
      /home/travis/gopath/src/github.com/hashicorp/memberlist/state.go:181 +0x116
  github.com/hashicorp/memberlist.*Memberlist.(github.com/hashicorp/memberlist.probe)·fm()
      /home/travis/gopath/src/github.com/hashicorp/memberlist/state.go:71 +0x33
  github.com/hashicorp/memberlist.(*Memberlist).triggerFunc()
      /home/travis/gopath/src/github.com/hashicorp/memberlist/state.go:107 +0xd5
Previous read by goroutine 47:
  github.com/hashicorp/memberlist.func·001()
      /home/travis/gopath/src/github.com/hashicorp/memberlist/memberlist.go:121 +0x4f
  github.com/hashicorp/memberlist.(*TransmitLimitedQueue).GetBroadcasts()
      /home/travis/gopath/src/github.com/hashicorp/memberlist/queue.go:80 +0x126
  github.com/hashicorp/memberlist.(*Memberlist).getBroadcasts()
      /home/travis/gopath/src/github.com/hashicorp/memberlist/broadcast.go:74 +0xa3
  github.com/hashicorp/memberlist.(*Memberlist).gossip()
      /home/travis/gopath/src/github.com/hashicorp/memberlist/state.go:313 +0x3f4
  github.com/hashicorp/memberlist.*Memberlist.(github.com/hashicorp/memberlist.gossip)·fm()
      /home/travis/gopath/src/github.com/hashicorp/memberlist/state.go:83 +0x33
  github.com/hashicorp/memberlist.(*Memberlist).triggerFunc()
      /home/travis/gopath/src/github.com/hashicorp/memberlist/state.go:107 +0xd5
Goroutine 54 (running) created at:
  github.com/hashicorp/memberlist.(*Memberlist).schedule()
      /home/travis/gopath/src/github.com/hashicorp/memberlist/state.go:71 +0x237
  github.com/hashicorp/memberlist.Create()
      /home/travis/gopath/src/github.com/hashicorp/memberlist/memberlist.go:142 +0xe8
  github.com/hashicorp/serf/serf.Create()
      /home/travis/gopath/src/github.com/hashicorp/serf/serf/serf.go:352 +0x20f2
  github.com/bitly/nsq/nsqd.initSerf()
      /home/travis/gopath/src/github.com/bitly/nsq/nsqd/gossip.go:101 +0xba4
  github.com/bitly/nsq/nsqd.(*NSQD).Main()
      /home/travis/gopath/src/github.com/bitly/nsq/nsqd/nsqd.go:253 +0x122e
  github.com/bitly/nsq/nsqd.mustStartNSQD()
      /home/travis/gopath/src/github.com/bitly/nsq/nsqd/protocol_v2_test.go:39 +0x1b8
  github.com/bitly/nsq/nsqd.TestRegossip()
      /home/travis/gopath/src/github.com/bitly/nsq/nsqd/gossip_test.go:134 +0x564
  testing.tRunner()
      /home/travis/.gvm/gos/go1.3.3/src/pkg/testing/testing.go:422 +0x10f
Goroutine 47 (running) created at:
  github.com/hashicorp/memberlist.(*Memberlist).schedule()
      /home/travis/gopath/src/github.com/hashicorp/memberlist/state.go:83 +0x586
  github.com/hashicorp/memberlist.Create()
      /home/travis/gopath/src/github.com/hashicorp/memberlist/memberlist.go:142 +0xe8
  github.com/hashicorp/serf/serf.Create()
      /home/travis/gopath/src/github.com/hashicorp/serf/serf/serf.go:352 +0x20f2
  github.com/bitly/nsq/nsqd.initSerf()
      /home/travis/gopath/src/github.com/bitly/nsq/nsqd/gossip.go:101 +0xba4
  github.com/bitly/nsq/nsqd.(*NSQD).Main()
      /home/travis/gopath/src/github.com/bitly/nsq/nsqd/nsqd.go:253 +0x122e
  github.com/bitly/nsq/nsqd.mustStartNSQD()
      /home/travis/gopath/src/github.com/bitly/nsq/nsqd/protocol_v2_test.go:39 +0x1b8
  github.com/bitly/nsq/nsqd.TestRegossip()
      /home/travis/gopath/src/github.com/bitly/nsq/nsqd/gossip_test.go:134 +0x564
  testing.tRunner()
      /home/travis/.gvm/gos/go1.3.3/src/pkg/testing/testing.go:422 +0x10f
==================
```

Simple fix attached...