### PR TITLE
Custom errors for merge delegate

### DIFF
--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -362,10 +362,10 @@ type CustomMergeDelegate struct {
 	invoked bool
 }
 
-func (c *CustomMergeDelegate) NotifyMerge(nodes []*Node) (cancel bool) {
+func (c *CustomMergeDelegate) NotifyMerge(nodes []*Node) error {
 	log.Printf("Cancel merge")
 	c.invoked = true
-	return true
+	return fmt.Errorf("Custom merge canceled")
 }
 
 func TestMemberlist_Join_Cancel(t *testing.T) {
@@ -395,7 +395,7 @@ func TestMemberlist_Join_Cancel(t *testing.T) {
 	if num != 0 {
 		t.Fatalf("unexpected 0: %d", num)
 	}
-	if err.Error() != "Merge canceled" {
+	if err.Error() != "Custom merge canceled" {
 		t.Fatalf("unexpected err: %s", err)
 	}
 

--- a/merge_delegate.go
+++ b/merge_delegate.go
@@ -8,6 +8,7 @@ package memberlist
 // as part of the push-pull anti-entropy.
 type MergeDelegate interface {
 	// NotifyMerge is invoked when a merge could take place.
-	// Provides a list of the nodes known by the peer.
-	NotifyMerge(peers []*Node) (cancel bool)
+	// Provides a list of the nodes known by the peer. If
+	// the return value is non-nil, the merge is canceled.
+	NotifyMerge(peers []*Node) error
 }

--- a/net.go
+++ b/net.go
@@ -221,8 +221,8 @@ func (m *Memberlist) handleConn(conn *net.TCPConn) {
 				DCur: n.Vsn[5],
 			}
 		}
-		if m.config.Merge.NotifyMerge(nodes) {
-			m.logger.Printf("[WARN] memberlist: Cluster merge canceled")
+		if err := m.config.Merge.NotifyMerge(nodes); err != nil {
+			m.logger.Printf("[WARN] memberlist: Cluster merge canceled: %s", err)
 			return
 		}
 	}

--- a/state.go
+++ b/state.go
@@ -380,9 +380,9 @@ func (m *Memberlist) pushPullNode(addr []byte, port uint16, join bool) error {
 				DCur: n.Vsn[5],
 			}
 		}
-		if m.config.Merge.NotifyMerge(nodes) {
-			m.logger.Printf("[WARN] memberlist: Cluster merge canceled")
-			return fmt.Errorf("Merge canceled")
+		if err := m.config.Merge.NotifyMerge(nodes); err != nil {
+			m.logger.Printf("[WARN] memberlist: Cluster merge canceled: %s", err)
+			return err
 		}
 	}
 


### PR DESCRIPTION
Allows `NotifyMerge()` to return an error instead of just a bool. This makes it easier to identify why a merge is canceled.