### PR TITLE
Make it possible to return `k` nodes

### DIFF
--- a/util.go
+++ b/util.go
@@ -155,7 +155,7 @@ OUTER:
 	// Probe up to 3*n times, with large n this is not necessary
 	// since k << n, but with small n we want search to be
 	// exhaustive
-	for i := 0; i < 3*n && len(kNodes) < k; i++ {
+	for i := 0; i < 3*n && len(kNodes) <= k; i++ {
 		// Get random node
 		idx := randomOffset(n)
 		node := nodes[idx]


### PR DESCRIPTION
I realize the function documentation states that this could return fewer than `k` nodes. But with the current implementation it will *always* return fewer than `k` nodes which doesn't seem expected.

With a slight restructuring this function could also be made to always return either `k` nodes or the current alive node count minus this host and excluded hosts, whichever is smaller. If that's desirable then I'll open a PR for that.