### PR TITLE
LocalNode uses assigned port rather than the Config.BindPort

### DIFF
--- a/memberlist.go
+++ b/memberlist.go
@@ -289,7 +289,9 @@ func (m *Memberlist) setAlive() error {
 			addr := m.tcpListener.Addr().(*net.TCPAddr)
 			advertiseAddr = addr.IP
 		}
-		advertisePort = m.config.BindPort
+
+		// Use the port we are bound to.
+		advertisePort = m.tcpListener.Addr().(*net.TCPAddr).Port
 	}
 
 	// Check if this is a public address without encryption


### PR DESCRIPTION
Create a Node using its bound port rather than the port specified in the Config. There is a distinction when the Config specifies port 0, allowing Memberlist to bind to any free port. This change does not effect the port if an AdvertiseAddr/AdvertisePort is explicitly set in the Config.