### PR TITLE
Adds TCP direct pings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,22 @@ be disabled entirely.
 
 Failure detection is done by periodic random probing using a configurable interval.
 If the node fails to ack within a reasonable time (typically some multiple
-of RTT), then an indirect probe is attempted. An indirect probe asks a
-configurable number of random nodes to probe the same node, in case there
-are network issues causing our own node to fail the probe. If both our
-probe and the indirect probes fail within a reasonable time, then the
-node is marked "suspicious" and this knowledge is gossiped to the cluster.
-A suspicious node is still considered a member of cluster. If the suspect member
-of the cluster does not disputes the suspicion within a configurable period of
-time, the node is finally considered dead, and this state is then gossiped
-to the cluster.
+of RTT), then an indirect probe as well as a direct TCP probe are attempted. An
+indirect probe asks a configurable number of random nodes to probe the same node,
+in case there are network issues causing our own node to fail the probe. The direct
+TCP probe is used to help identify the common situation where networking is
+misconfigured to allow TCP but not UDP. Without the TCP probe, a UDP-isolated node
+would think all other nodes were suspect and could cause churn in the cluster when
+it attempts a TCP-based state exchange with another node. It is not desirable to
+operate with only TCP connectivity because convergence will be much slower, but it
+is enabled so that memberlist can detect this situation and alert operators.
+
+If both our probe, the indirect probes, and the direct TCP probe fail within a
+configurable time, then the node is marked "suspicious" and this knowledge is
+gossiped to the cluster. A suspicious node is still considered a member of
+cluster. If the suspect member of the cluster does not dispute the suspicion
+within a configurable period of time, the node is finally considered dead,
+and this state is then gossiped to the cluster.
 
 This is a brief and incomplete description of the protocol. For a better idea,
 please read the

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -70,39 +70,47 @@ func (m *MockDelegate) MergeRemoteState(s []byte, join bool) {
 	m.remoteState = s
 }
 
+// Returns a new Memberlist on an open port by trying a range of port numbers
+// until something sticks.
+func NewMemberlistOnOpenPort(c *Config) (*Memberlist, error) {
+	var m *Memberlist
+	var err error
+	for i := 0; i < 100; i++ {
+		m, err = newMemberlist(c)
+		if err == nil {
+			return m, nil
+		}
+		c.BindPort++
+	}
+
+	return nil, err
+}
+
 func GetMemberlistDelegate(t *testing.T) (*Memberlist, *MockDelegate) {
 	d := &MockDelegate{}
 
 	c := testConfig()
 	c.Delegate = d
 
-	var m *Memberlist
-	var err error
-	for i := 0; i < 100; i++ {
-		m, err = newMemberlist(c)
-		if err == nil {
-			return m, d
-		}
-		c.BindPort++
+	m, err := NewMemberlistOnOpenPort(c)
+	if err != nil {
+		t.Fatalf("failed to start: %v", err)
+		return nil, nil
 	}
-	t.Fatalf("failed to start: %v", err)
-	return nil, nil
+
+	return m, d
 }
 
 func GetMemberlist(t *testing.T) *Memberlist {
 	c := testConfig()
 
-	var m *Memberlist
-	var err error
-	for i := 0; i < 100; i++ {
-		m, err = newMemberlist(c)
-		if err == nil {
-			return m
-		}
-		c.BindPort++
+	m, err := NewMemberlistOnOpenPort(c)
+	if err != nil {
+		t.Fatalf("failed to start: %v", err)
+		return nil
 	}
-	t.Fatalf("failed to start: %v", err)
-	return nil
+
+	return m
 }
 
 func TestDefaultLANConfig_protocolVersion(t *testing.T) {
@@ -942,47 +950,56 @@ func TestMemberlist_Join_DeadNode(t *testing.T) {
 	}
 }
 
-func TestMemberlist_Join_Proto1And2(t *testing.T) {
-	// Create first node, protocol 2
-	m1 := GetMemberlist(t)
-	m1.setAlive()
-	m1.schedule()
-	defer m1.Shutdown()
-	if m1.config.ProtocolVersion != 2 {
-		t.Fatalf("expected version 2")
+// Tests that nodes running different versions of the protocol can successfully
+// discover each other and add themselves to their respective member lists.
+func TestMemberlist_Join_Prototocol_Compatibility(t *testing.T) {
+	testProtocolVersionPair := func(t *testing.T, pv1 uint8, pv2 uint8) {
+		c1 := testConfig()
+		c1.ProtocolVersion = pv1
+		m1, err := NewMemberlistOnOpenPort(c1)
+		if err != nil {
+			t.Fatalf("failed to start: %v", err)
+		}
+		m1.setAlive()
+		m1.schedule()
+		defer m1.Shutdown()
+
+		c2 := DefaultLANConfig()
+		addr1 := getBindAddr()
+		c2.Name = addr1.String()
+		c2.BindAddr = addr1.String()
+		c2.BindPort = m1.config.BindPort
+		c2.ProtocolVersion = pv2
+
+		m2, err := Create(c2)
+		if err != nil {
+			t.Fatalf("unexpected err: %s", err)
+		}
+		defer m2.Shutdown()
+
+		num, err := m2.Join([]string{m1.config.BindAddr})
+		if num != 1 {
+			t.Fatalf("unexpected 1: %d", num)
+		}
+		if err != nil {
+			t.Fatalf("unexpected err: %s", err)
+		}
+
+		// Check the hosts
+		if len(m2.Members()) != 2 {
+			t.Fatalf("should have 2 nodes! %v", m2.Members())
+		}
+
+		// Check the hosts
+		if len(m1.Members()) != 2 {
+			t.Fatalf("should have 2 nodes! %v", m2.Members())
+		}
 	}
 
-	// Create a second node, lower protocol!
-	c := DefaultLANConfig()
-	addr1 := getBindAddr()
-	c.Name = addr1.String()
-	c.BindAddr = addr1.String()
-	c.BindPort = m1.config.BindPort
-	c.ProtocolVersion = 1
-
-	m2, err := Create(c)
-	if err != nil {
-		t.Fatalf("unexpected err: %s", err)
-	}
-	defer m2.Shutdown()
-
-	num, err := m2.Join([]string{m1.config.BindAddr})
-	if num != 1 {
-		t.Fatalf("unexpected 1: %d", num)
-	}
-	if err != nil {
-		t.Fatalf("unexpected err: %s", err)
-	}
-
-	// Check the hosts
-	if len(m2.Members()) != 2 {
-		t.Fatalf("should have 2 nodes! %v", m2.Members())
-	}
-
-	// Check the hosts
-	if len(m1.Members()) != 2 {
-		t.Fatalf("should have 2 nodes! %v", m2.Members())
-	}
+	testProtocolVersionPair(t, 2, 1)
+	testProtocolVersionPair(t, 2, 3)
+	testProtocolVersionPair(t, 3, 2)
+	testProtocolVersionPair(t, 3, 1)
 }
 
 func TestMemberlist_Join_IPv6(t *testing.T) {

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -992,7 +992,7 @@ func TestMemberlist_Join_Prototocol_Compatibility(t *testing.T) {
 
 		// Check the hosts
 		if len(m1.Members()) != 2 {
-			t.Fatalf("should have 2 nodes! %v", m2.Members())
+			t.Fatalf("should have 2 nodes! %v", m1.Members())
 		}
 	}
 

--- a/net.go
+++ b/net.go
@@ -196,17 +196,19 @@ func (m *Memberlist) handleConn(conn *net.TCPConn) {
 	defer conn.Close()
 	metrics.IncrCounter([]string{"memberlist", "tcp", "accept"}, 1)
 
+	conn.SetDeadline(time.Now().Add(m.config.TCPTimeout))
 	msgType, bufConn, dec, err := m.readTCP(conn)
 	if err != nil {
 		m.logger.Printf("[ERR] memberlist: failed to receive: %s", err)
 		return
 	}
 
-	if msgType == userMsg {
+	switch msgType {
+	case userMsg:
 		if err := m.readUserMsg(bufConn, dec); err != nil {
 			m.logger.Printf("[ERR] memberlist: Failed to receive user message: %s", err)
 		}
-	} else if msgType == pushPullMsg {
+	case pushPullMsg:
 		join, remoteNodes, userState, err := m.readRemoteState(bufConn, dec)
 		if err != nil {
 			m.logger.Printf("[ERR] memberlist: Failed to read remote state: %s", err)
@@ -221,7 +223,31 @@ func (m *Memberlist) handleConn(conn *net.TCPConn) {
 		if err := m.mergeRemoteState(join, remoteNodes, userState); err != nil {
 			return
 		}
-	} else {
+	case pingMsg:
+		var p ping
+		if err := dec.Decode(&p); err != nil {
+			m.logger.Printf("[ERR] memberlist: Failed to decode TCP ping: %s", err)
+			return
+		}
+
+		if p.Node != "" && p.Node != m.config.Name {
+			m.logger.Printf("[WARN] memberlist: Got ping for unexpected node %s", p.Node)
+			return
+		}
+
+		ack := ackResp{p.SeqNo, nil}
+		out, err := encode(ackRespMsg, &ack)
+		if err != nil {
+			m.logger.Printf("[ERR] memeberlist: Failed to encode TCP ack: %s", err)
+			return
+		}
+
+		err = m.rawSendMsgTCP(conn, out.Bytes())
+		if err != nil {
+			m.logger.Printf("[ERR] memberlist: Failed to send TCP ack: %s", err)
+			return
+		}
+	default:
 		m.logger.Printf("[ERR] memberlist: Received invalid msgType (%d)", msgType)
 	}
 }
@@ -654,6 +680,7 @@ func (m *Memberlist) sendAndReceiveState(addr []byte, port uint16, join bool) ([
 		return nil, nil, err
 	}
 
+	conn.SetDeadline(time.Now().Add(m.config.TCPTimeout))
 	msgType, bufConn, dec, err := m.readTCP(conn)
 	if err != nil {
 		return nil, nil, err
@@ -789,9 +816,6 @@ func (m *Memberlist) decryptRemoteState(bufConn io.Reader) ([]byte, error) {
 // readTCP is used to read the start of a TCP stream.
 // it decrypts and decompresses the stream if necessary
 func (m *Memberlist) readTCP(conn net.Conn) (messageType, io.Reader, *codec.Decoder, error) {
-	// Setup a deadline
-	conn.SetDeadline(time.Now().Add(m.config.TCPTimeout))
-
 	// Created a buffered reader
 	var bufConn io.Reader = bufio.NewReader(conn)
 
@@ -934,7 +958,7 @@ func (m *Memberlist) mergeRemoteState(join bool, remoteNodes []pushNodeState, us
 	return nil
 }
 
-// readUserMsg is used to decode a UserMsg from a TCP stream
+// readUserMsg is used to decode a userMsg from a TCP stream
 func (m *Memberlist) readUserMsg(bufConn io.Reader, dec *codec.Decoder) error {
 	// Read the user message header
 	var header userMsgHeader
@@ -960,6 +984,40 @@ func (m *Memberlist) readUserMsg(bufConn io.Reader, dec *codec.Decoder) error {
 		if d != nil {
 			d.NotifyMsg(userBuf)
 		}
+	}
+
+	return nil
+}
+
+// sendPingAndWaitForAck uses the given TCP connection, sends a ping, and waits
+// for an ack. All of this is done in blocking fashion, and if the exchange is
+// good, a nil error will be returned to the caller.
+func (m *Memberlist) sendPingAndWaitForAck(conn net.Conn, ping ping) error {
+	out, err := encode(pingMsg, &ping)
+	if err != nil {
+		return err
+	}
+
+	if err = m.rawSendMsgTCP(conn, out.Bytes()); err != nil {
+		return err
+	}
+
+	msgType, _, dec, err := m.readTCP(conn)
+	if err != nil {
+		return err
+	}
+
+	if msgType != ackRespMsg {
+		return fmt.Errorf("unexpected msgType (%d) from TCP ping", msgType)
+	}
+
+	var ack ackResp
+	if err := dec.Decode(&ack); err != nil {
+		return err
+	}
+
+	if ack.SeqNo != ping.SeqNo {
+		return fmt.Errorf("sequence number from ack (%d) doesn't match ping (%d)", ack.SeqNo, ping.SeqNo)
 	}
 
 	return nil

--- a/net.go
+++ b/net.go
@@ -238,7 +238,7 @@ func (m *Memberlist) handleConn(conn *net.TCPConn) {
 		ack := ackResp{p.SeqNo, nil}
 		out, err := encode(ackRespMsg, &ack)
 		if err != nil {
-			m.logger.Printf("[ERR] memeberlist: Failed to encode TCP ack: %s", err)
+			m.logger.Printf("[ERR] memberlist: Failed to encode TCP ack: %s", err)
 			return
 		}
 

--- a/net.go
+++ b/net.go
@@ -18,7 +18,7 @@ import (
 // range. This range is inclusive.
 const (
 	ProtocolVersionMin uint8 = 1
-	ProtocolVersionMax       = 2
+	ProtocolVersionMax       = 3
 )
 
 // messageType is an integer ID of a type of message that can be received

--- a/net_test.go
+++ b/net_test.go
@@ -258,7 +258,7 @@ func TestTCPPing(t *testing.T) {
 	m := GetMemberlist(t)
 	defer m.Shutdown()
 	pingTimeout := m.config.ProbeInterval
-	pingTimeMax := m.config.ProbeInterval + 10 * time.Millisecond
+	pingTimeMax := m.config.ProbeInterval + 10*time.Millisecond
 
 	// Do a normal round trip.
 	pingOut := ping{SeqNo: 23, Node: "mongo"}

--- a/net_test.go
+++ b/net_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -233,6 +234,174 @@ func TestHandleIndirectPing(t *testing.T) {
 
 	if ack.SeqNo != 100 {
 		t.Fatalf("bad sequence no")
+	}
+}
+
+func TestTCPPing(t *testing.T) {
+	var tcp *net.TCPListener
+	var tcpAddr *net.TCPAddr
+	for port := 60000; port < 61000; port++ {
+		tcpAddr = &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: port}
+		tcpLn, err := net.ListenTCP("tcp", tcpAddr)
+		if err == nil {
+			tcp = tcpLn
+			break
+		}
+	}
+	if tcp == nil {
+		t.Fatalf("no tcp listener")
+	}
+	defer tcp.Close()
+
+	m := GetMemberlist(t)
+	defer m.Shutdown()
+	pingTimeout := m.config.ProbeInterval
+	pingTimeMax := m.config.ProbeInterval + 10 * time.Millisecond
+
+	// Do a normal round trip.
+	pingOut := ping{SeqNo: 23, Node: "mongo"}
+	go func() {
+		tcp.SetDeadline(time.Now().Add(pingTimeMax))
+		conn, err := tcp.AcceptTCP()
+		if err != nil {
+			t.Fatalf("failed to connect: %s", err)
+		}
+
+		msgType, _, dec, err := m.readTCP(conn)
+		if err != nil {
+			t.Fatalf("failed to read ping: %s", err)
+		}
+
+		if msgType != pingMsg {
+			t.Fatalf("expecting ping, got message type (%d)", msgType)
+		}
+
+		var pingIn ping
+		if err := dec.Decode(&pingIn); err != nil {
+			t.Fatalf("failed to decode ping: %s", err)
+		}
+
+		if pingIn.SeqNo != pingOut.SeqNo {
+			t.Fatalf("sequence number isn't correct (%d) vs (%d)", pingIn.SeqNo, pingOut.SeqNo)
+		}
+
+		if pingIn.Node != pingOut.Node {
+			t.Fatalf("node name isn't correct (%s) vs (%s)", pingIn.Node, pingOut.Node)
+		}
+
+		ack := ackResp{pingIn.SeqNo, nil}
+		out, err := encode(ackRespMsg, &ack)
+		if err != nil {
+			t.Fatalf("failed to encode ack: %s", err)
+		}
+
+		err = m.rawSendMsgTCP(conn, out.Bytes())
+		if err != nil {
+			t.Fatalf("failed to send ack: %s", err)
+		}
+	}()
+	deadline := time.Now().Add(pingTimeout)
+	didContact, err := m.sendPingAndWaitForAck(tcpAddr, pingOut, deadline)
+	if err != nil {
+		t.Fatalf("error trying to ping: %s", err)
+	}
+	if !didContact {
+		t.Fatalf("expected successful ping")
+	}
+
+	// Make sure a mis-matched sequence number is caught.
+	go func() {
+		tcp.SetDeadline(time.Now().Add(pingTimeMax))
+		conn, err := tcp.AcceptTCP()
+		if err != nil {
+			t.Fatalf("failed to connect: %s", err)
+		}
+
+		_, _, dec, err := m.readTCP(conn)
+		if err != nil {
+			t.Fatalf("failed to read ping: %s", err)
+		}
+
+		var pingIn ping
+		if err := dec.Decode(&pingIn); err != nil {
+			t.Fatalf("failed to decode ping: %s", err)
+		}
+
+		ack := ackResp{pingIn.SeqNo + 1, nil}
+		out, err := encode(ackRespMsg, &ack)
+		if err != nil {
+			t.Fatalf("failed to encode ack: %s", err)
+		}
+
+		err = m.rawSendMsgTCP(conn, out.Bytes())
+		if err != nil {
+			t.Fatalf("failed to send ack: %s", err)
+		}
+	}()
+	deadline = time.Now().Add(pingTimeout)
+	didContact, err = m.sendPingAndWaitForAck(tcpAddr, pingOut, deadline)
+	if err == nil || !strings.Contains(err.Error(), "sequence number") {
+		t.Fatalf("expected an error from mis-matched sequence number")
+	}
+	if didContact {
+		t.Fatalf("expected failed ping")
+	}
+
+	// Make sure an unexpected message type is handled gracefully.
+	go func() {
+		tcp.SetDeadline(time.Now().Add(pingTimeMax))
+		conn, err := tcp.AcceptTCP()
+		if err != nil {
+			t.Fatalf("failed to connect: %s", err)
+		}
+
+		_, _, _, err = m.readTCP(conn)
+		if err != nil {
+			t.Fatalf("failed to read ping: %s", err)
+		}
+
+		bogus := indirectPingReq{}
+		out, err := encode(indirectPingMsg, &bogus)
+		if err != nil {
+			t.Fatalf("failed to encode bogus msg: %s", err)
+		}
+
+		err = m.rawSendMsgTCP(conn, out.Bytes())
+		if err != nil {
+			t.Fatalf("failed to send bogus msg: %s", err)
+		}
+	}()
+	deadline = time.Now().Add(pingTimeout)
+	didContact, err = m.sendPingAndWaitForAck(tcpAddr, pingOut, deadline)
+	if err == nil || !strings.Contains(err.Error(), "unexpected msgType") {
+		t.Fatalf("expected an error from bogus message")
+	}
+	if didContact {
+		t.Fatalf("expected failed ping")
+	}
+
+	// Make sure failed I/O respects the deadline.
+	go func() {
+		tcp.SetDeadline(time.Now().Add(pingTimeMax))
+		_, err := tcp.AcceptTCP()
+		if err != nil {
+			t.Fatalf("failed to connect: %s", err)
+		}
+
+		time.Sleep(2 * pingTimeMax)
+	}()
+	deadline = time.Now().Add(pingTimeout)
+	startPing := time.Now()
+	didContact, err = m.sendPingAndWaitForAck(tcpAddr, pingOut, deadline)
+	pingTime := time.Now().Sub(startPing)
+	if err == nil {
+		t.Fatalf("expected an error while trying to ping")
+	}
+	if didContact {
+		t.Fatalf("expected failed ping")
+	}
+	if pingTime > pingTimeMax {
+		t.Fatalf("took too long to fail ping, %9.6f", pingTime.Seconds())
 	}
 }
 

--- a/ping_delegate.go
+++ b/ping_delegate.go
@@ -4,7 +4,8 @@ import "time"
 
 // PingDelegate is used to notify an observer how long it took for a ping message to
 // complete a round trip.  It can also be used for writing arbitrary byte slices
-// into ack messages.
+// into ack messages. Note that in order to be meaningful for RTT estimates, this
+// delegate does not apply to indirect pings, nor fallback pings sent over TCP.
 type PingDelegate interface {
 	// AckPayload is invoked when an ack is being sent; the returned bytes will be appended to the ack
 	AckPayload() []byte

--- a/state.go
+++ b/state.go
@@ -264,7 +264,7 @@ func (m *Memberlist) probeNode(node *nodeState) {
 	// misinformation to other nodes via anti-entropy), avoiding flapping in
 	// the cluster.
 	fallbackCh := make(chan bool)
-	if node.PMax >= 3 {
+	if m.ProtocolVersion() >= 3 && node.PMax >= 3 {
 		destAddr := &net.TCPAddr{IP: node.Addr, Port: int(node.Port)}
 		go func() {
 			defer close(fallbackCh)
@@ -295,7 +295,7 @@ func (m *Memberlist) probeNode(node *nodeState) {
 	// any additional time here.
 	for didContact := range fallbackCh {
 		if didContact {
-			m.logger.Printf("memberlist: Was able to reach %s via TCP but not UDP, network may be misconfigured and not allowing bidirectional UDP", node.Name)
+			m.logger.Printf("[WARN] memberlist: Was able to reach %s via TCP but not UDP, network may be misconfigured and not allowing bidirectional UDP", node.Name)
 			return
 		}
 	}

--- a/state_test.go
+++ b/state_test.go
@@ -135,9 +135,9 @@ func TestMemberList_ProbeNode_FallbackTCP(t *testing.T) {
 	// Make sure m4 is configured with the same protocol version as m1 so
 	// the TCP fallback behavior is enabled.
 	a4 := alive{
-		Node: addr4.String(),
-		Addr: ip4,
-		Port: 7946,
+		Node:        addr4.String(),
+		Addr:        ip4,
+		Port:        7946,
 		Incarnation: 1,
 		Vsn: []uint8{
 			ProtocolVersionMin, ProtocolVersionMax,


### PR DESCRIPTION
Here's an initial cut at the fix for hashicorp/consul#742. It adds a TCP-based direct ping pipelined with the normal UDP indirect pings if the direct UDP ping fails. If all the UDP-based pings fail and the TCP-based ping works, then a log message will be generated to alert the user that their networking config isn't right.