### PR TITLE
Added Key documentation and godoc image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# memberlist
+# memberlist [![GoDoc](https://godoc.org/github.com/hashicorp/memberlist?status.png)](https://godoc.org/github.com/hashicorp/memberlist)
 
 memberlist is a [Go](http://www.golang.org) library that manages cluster
 membership and member failure detection using a gossip based protocol.

--- a/config.go
+++ b/config.go
@@ -111,6 +111,8 @@ type Config struct {
 	// the first key used while attempting to decrypt messages. Providing a
 	// value for this primary key will enable message-level encryption and
 	// verification, and automatically install the key onto the keyring.
+	// The value should be either 16, 24, or 32 bytes to select AES-128, 
+	// AES-192, or AES-256. 
 	SecretKey []byte
 
 	// The keyring holds all of the encryption keys used internally. It is

--- a/keyring.go
+++ b/keyring.go
@@ -34,6 +34,9 @@ func (k *Keyring) init() {
 // keyring. If creating a keyring with multiple keys, one key must be designated
 // primary by passing it as the primaryKey. If the primaryKey does not exist in
 // the list of secondary keys, it will be automatically added at position 0.
+//
+// A key should be either 16, 24, or 32 bytes to select AES-128, 
+// AES-192, or AES-256. 
 func NewKeyring(keys [][]byte, primaryKey []byte) (*Keyring, error) {
 	keyring := &Keyring{}
 	keyring.init()
@@ -58,6 +61,9 @@ func NewKeyring(keys [][]byte, primaryKey []byte) (*Keyring, error) {
 // AddKey will install a new key on the ring. Adding a key to the ring will make
 // it available for use in decryption. If the key already exists on the ring,
 // this function will just return noop.
+//
+// key should be either 16, 24, or 32 bytes to select AES-128, 
+// AES-192, or AES-256. 
 func (k *Keyring) AddKey(key []byte) error {
 	// Encorce 16-byte key size
 	if len(key) != 16 {


### PR DESCRIPTION
- See https://golang.org/pkg/crypto/aes/#NewCipher for AES docs
- Even though https://golang.org/pkg/crypto/cipher/#NewGCM says it
  works with a 128-bit block cipher it also works with 192 and 256.
  See http://play.golang.org/p/-pXkfFyKE9 as example.