### PR TITLE
discover port on which node binds, if not specified

### DIFF
--- a/memberlist.go
+++ b/memberlist.go
@@ -89,6 +89,9 @@ func newMemberlist(conf *Config) (*Memberlist, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to start TCP listener. Err: %s", err)
 	}
+	if conf.BindPort == 0 {
+		conf.BindPort = tcpLn.Addr().(*net.TCPAddr).Port
+	}
 
 	udpAddr := &net.UDPAddr{IP: net.ParseIP(conf.BindAddr), Port: conf.BindPort}
 	udpLn, err := net.ListenUDP("udp", udpAddr)

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -73,17 +73,8 @@ func (m *MockDelegate) MergeRemoteState(s []byte, join bool) {
 // Returns a new Memberlist on an open port by trying a range of port numbers
 // until something sticks.
 func NewMemberlistOnOpenPort(c *Config) (*Memberlist, error) {
-	var m *Memberlist
-	var err error
-	for i := 0; i < 100; i++ {
-		m, err = newMemberlist(c)
-		if err == nil {
-			return m, nil
-		}
-		c.BindPort++
-	}
-
-	return nil, err
+	c.BindPort = 0
+	return newMemberlist(c)
 }
 
 func GetMemberlistDelegate(t *testing.T) (*Memberlist, *MockDelegate) {


### PR DESCRIPTION
When using a configuration with `BindPort=0` so that a random available port be used, I was receiving a bunch of warnings:

```
2015/08/17 18:09:16 [WARN] memberlist: Was able to reach {{hostname}} via TCP but not UDP, network may be misconfigured and not allowing bidirectional UDP
```

Guessing that the problem was the TCP listener was not updating the `BindPort` for the UDP listener, I implemented this fix. It also makes the `NewMemberlistOnOpenPort` function simpler and more likely to succeed.