### PR TITLE
Improves accuracy of RTT estimates.

### DIFF
--- a/net.go
+++ b/net.go
@@ -281,6 +281,10 @@ func (m *Memberlist) udpListen() {
 			continue
 		}
 
+		// Capture the reception time of the packet as close to the
+		// system calls as possible.
+		lastPacket = time.Now()
+
 		// Check the length
 		if n < 1 {
 			m.logger.Printf("[ERR] memberlist: UDP packet too short (%d bytes). From: %s",
@@ -288,16 +292,13 @@ func (m *Memberlist) udpListen() {
 			continue
 		}
 
-		// Capture the current time
-		lastPacket = time.Now()
-
 		// Ingest this packet
 		metrics.IncrCounter([]string{"memberlist", "udp", "received"}, float32(n))
-		m.ingestPacket(buf[:n], addr)
+		m.ingestPacket(buf[:n], addr, lastPacket)
 	}
 }
 
-func (m *Memberlist) ingestPacket(buf []byte, from net.Addr) {
+func (m *Memberlist) ingestPacket(buf []byte, from net.Addr, timestamp time.Time) {
 	// Check if encryption is enabled
 	if m.config.EncryptionEnabled() {
 		// Decrypt the payload
@@ -312,10 +313,10 @@ func (m *Memberlist) ingestPacket(buf []byte, from net.Addr) {
 	}
 
 	// Handle the command
-	m.handleCommand(buf, from)
+	m.handleCommand(buf, from, timestamp)
 }
 
-func (m *Memberlist) handleCommand(buf []byte, from net.Addr) {
+func (m *Memberlist) handleCommand(buf []byte, from net.Addr, timestamp time.Time) {
 	// Decode the message type
 	msgType := messageType(buf[0])
 	buf = buf[1:]
@@ -323,16 +324,16 @@ func (m *Memberlist) handleCommand(buf []byte, from net.Addr) {
 	// Switch on the msgType
 	switch msgType {
 	case compoundMsg:
-		m.handleCompound(buf, from)
+		m.handleCompound(buf, from, timestamp)
 	case compressMsg:
-		m.handleCompressed(buf, from)
+		m.handleCompressed(buf, from, timestamp)
 
 	case pingMsg:
 		m.handlePing(buf, from)
 	case indirectPingMsg:
 		m.handleIndirectPing(buf, from)
 	case ackRespMsg:
-		m.handleAck(buf, from)
+		m.handleAck(buf, from, timestamp)
 
 	case suspectMsg:
 		fallthrough
@@ -382,7 +383,7 @@ func (m *Memberlist) udpHandler() {
 	}
 }
 
-func (m *Memberlist) handleCompound(buf []byte, from net.Addr) {
+func (m *Memberlist) handleCompound(buf []byte, from net.Addr, timestamp time.Time) {
 	// Decode the parts
 	trunc, parts, err := decodeCompoundMessage(buf)
 	if err != nil {
@@ -397,7 +398,7 @@ func (m *Memberlist) handleCompound(buf []byte, from net.Addr) {
 
 	// Handle each message
 	for _, part := range parts {
-		m.handleCommand(part, from)
+		m.handleCommand(part, from, timestamp)
 	}
 }
 
@@ -441,16 +442,10 @@ func (m *Memberlist) handleIndirectPing(buf []byte, from net.Addr) {
 	destAddr := &net.UDPAddr{IP: ind.Target, Port: int(ind.Port)}
 
 	// Setup a response handler to relay the ack
-	sent := time.Now()
-	respHandler := func(payload []byte) {
+	respHandler := func(payload []byte, timestamp time.Time) {
 		ack := ackResp{ind.SeqNo, nil}
 		if err := m.encodeAndSendMsg(from, ackRespMsg, &ack); err != nil {
 			m.logger.Printf("[ERR] memberlist: Failed to forward ack: %s", err)
-		}
-		if m.config.Ping != nil {
-			if n, ok := m.nodeMap[ind.Node]; ok {
-				m.config.Ping.NotifyPingComplete(&n.Node, time.Now().Sub(sent), payload)
-			}
 		}
 	}
 	m.setAckHandler(localSeqNo, respHandler, m.config.ProbeTimeout)
@@ -461,13 +456,13 @@ func (m *Memberlist) handleIndirectPing(buf []byte, from net.Addr) {
 	}
 }
 
-func (m *Memberlist) handleAck(buf []byte, from net.Addr) {
+func (m *Memberlist) handleAck(buf []byte, from net.Addr, timestamp time.Time) {
 	var ack ackResp
 	if err := decode(buf, &ack); err != nil {
 		m.logger.Printf("[ERR] memberlist: Failed to decode ack response: %s", err)
 		return
 	}
-	m.invokeAckHandler(ack)
+	m.invokeAckHandler(ack, timestamp)
 }
 
 func (m *Memberlist) handleSuspect(buf []byte, from net.Addr) {
@@ -513,7 +508,7 @@ func (m *Memberlist) handleUser(buf []byte, from net.Addr) {
 }
 
 // handleCompressed is used to unpack a compressed message
-func (m *Memberlist) handleCompressed(buf []byte, from net.Addr) {
+func (m *Memberlist) handleCompressed(buf []byte, from net.Addr, timestamp time.Time) {
 	// Try to decode the payload
 	payload, err := decompressPayload(buf)
 	if err != nil {
@@ -522,7 +517,7 @@ func (m *Memberlist) handleCompressed(buf []byte, from net.Addr) {
 	}
 
 	// Recursively handle the payload
-	m.handleCommand(payload, from)
+	m.handleCommand(payload, from, timestamp)
 }
 
 // encodeAndSendMsg is used to combine the encoding and sending steps

--- a/state_test.go
+++ b/state_test.go
@@ -286,7 +286,7 @@ func TestMemberList_SetAckChannel(t *testing.T) {
 func TestMemberList_SetAckHandler(t *testing.T) {
 	m := &Memberlist{ackHandlers: make(map[uint32]*ackHandler)}
 
-	f := func([]byte) {}
+	f := func([]byte, time.Time) {}
 	m.setAckHandler(0, f, 10*time.Millisecond)
 
 	if _, ok := m.ackHandlers[0]; !ok {
@@ -303,14 +303,14 @@ func TestMemberList_InvokeAckHandler(t *testing.T) {
 	m := &Memberlist{ackHandlers: make(map[uint32]*ackHandler)}
 
 	// Does nothing
-	m.invokeAckHandler(ackResp{})
+	m.invokeAckHandler(ackResp{}, time.Now())
 
 	var b bool
-	f := func(payload []byte) { b = true }
+	f := func(payload []byte, timestamp time.Time) { b = true }
 	m.setAckHandler(0, f, 10*time.Millisecond)
 
 	// Should set b
-	m.invokeAckHandler(ackResp{0, nil})
+	m.invokeAckHandler(ackResp{0, nil}, time.Now())
 	if !b {
 		t.Fatalf("b not set")
 	}
@@ -325,13 +325,13 @@ func TestMemberList_InvokeAckHandler_Channel(t *testing.T) {
 
 	ack := ackResp{0, []byte{0, 0, 0}}
 	// Does nothing
-	m.invokeAckHandler(ack)
+	m.invokeAckHandler(ack, time.Now())
 
 	ch := make(chan ackMessage, 1)
 	m.setAckChannel(0, ch, 10*time.Millisecond)
 
 	// Should send message
-	m.invokeAckHandler(ack)
+	m.invokeAckHandler(ack, time.Now())
 
 	select {
 	case v := <-ch:


### PR DESCRIPTION
 * Plumbs the RX timestamp down from right after the receive call.
 * Moves the TX timestamp after the prep and send call.
 * Gets rid of the ping delegate call for indirect pings (the
   sequencing of the calls here make it hard to improve the
   accuracy without some complicated logic, and this is a degraded
   situation anyway).