### PR TITLE
Makes the default protocol 2 and lets 3 interoperate with 2.

### DIFF
--- a/config.go
+++ b/config.go
@@ -85,6 +85,11 @@ type Config struct {
 	ProbeInterval time.Duration
 	ProbeTimeout  time.Duration
 
+	// DisableTcpPings will turn off the fallback TCP pings that are attempted
+	// if the direct UDP ping fails. These get pipelined along with the
+	// indirect UDP pings.
+	DisableTcpPings bool
+
 	// GossipInterval and GossipNodes are used to configure the gossip
 	// behavior of memberlist.
 	//
@@ -156,7 +161,7 @@ func DefaultLANConfig() *Config {
 		BindPort:         7946,
 		AdvertiseAddr:    "",
 		AdvertisePort:    7946,
-		ProtocolVersion:  ProtocolVersionMax,
+		ProtocolVersion:  ProtocolVersion2Compatible,
 		TCPTimeout:       10 * time.Second,       // Timeout after 10 seconds
 		IndirectChecks:   3,                      // Use 3 nodes for the indirect ping
 		RetransmitMult:   4,                      // Retransmit a message 4 * log(N+1) nodes
@@ -164,6 +169,7 @@ func DefaultLANConfig() *Config {
 		PushPullInterval: 30 * time.Second,       // Low frequency
 		ProbeTimeout:     500 * time.Millisecond, // Reasonable RTT time for LAN
 		ProbeInterval:    1 * time.Second,        // Failure check every second
+		DisableTcpPings:  false,                  // TCP pings are safe, even with mixed versions
 
 		GossipNodes:    3,                      // Gossip to 3 nodes
 		GossipInterval: 200 * time.Millisecond, // Gossip more rapidly

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -115,7 +115,7 @@ func GetMemberlist(t *testing.T) *Memberlist {
 
 func TestDefaultLANConfig_protocolVersion(t *testing.T) {
 	c := DefaultLANConfig()
-	if c.ProtocolVersion != ProtocolVersionMax {
+	if c.ProtocolVersion != ProtocolVersion2Compatible {
 		t.Fatalf("should be max: %d", c.ProtocolVersion)
 	}
 }

--- a/net.go
+++ b/net.go
@@ -18,7 +18,15 @@ import (
 // range. This range is inclusive.
 const (
 	ProtocolVersionMin uint8 = 1
-	ProtocolVersionMax       = 3
+
+	// Version 3 added support for TCP pings but we kept the default
+	// protocol version at 2 to ease transition to this new feature.
+	// A memberlist speaking version 2 of the protocol will attempt
+	// to TCP ping another memberlist who understands version 3 or
+	// greater.
+	ProtocolVersion2Compatible = 2
+
+	ProtocolVersionMax = 3
 )
 
 // messageType is an integer ID of a type of message that can be received

--- a/net_test.go
+++ b/net_test.go
@@ -48,7 +48,7 @@ func TestHandleCompoundPing(t *testing.T) {
 
 	// Wait for responses
 	go func() {
-		time.Sleep(time.Second)
+		time.Sleep(2 * time.Second)
 		panic("timeout")
 	}()
 
@@ -108,7 +108,7 @@ func TestHandlePing(t *testing.T) {
 
 	// Wait for response
 	go func() {
-		time.Sleep(time.Second)
+		time.Sleep(2 * time.Second)
 		panic("timeout")
 	}()
 
@@ -211,7 +211,7 @@ func TestHandleIndirectPing(t *testing.T) {
 
 	// Wait for response
 	go func() {
-		time.Sleep(time.Second)
+		time.Sleep(2 * time.Second)
 		panic("timeout")
 	}()
 
@@ -563,7 +563,7 @@ func TestSendMsg_Piggyback(t *testing.T) {
 
 	// Wait for response
 	go func() {
-		time.Sleep(time.Second)
+		time.Sleep(2 * time.Second)
 		panic("timeout")
 	}()
 

--- a/state.go
+++ b/state.go
@@ -268,8 +268,13 @@ func (m *Memberlist) probeNode(node *nodeState) {
 	// but can still speak TCP (which also means they can possibly report
 	// misinformation to other nodes via anti-entropy), avoiding flapping in
 	// the cluster.
+	//
+	// This is a little unusual because we will attempt a TCP ping to any
+	// member who understands version 3 of the protocol, regardless of
+	// which protocol version we are speaking. That's why we've included a
+	// config option to turn this off if desired.
 	fallbackCh := make(chan bool)
-	if m.ProtocolVersion() >= 3 && node.PMax >= 3 {
+	if (!m.config.DisableTcpPings) && (node.PMax >= 3) {
 		destAddr := &net.TCPAddr{IP: node.Addr, Port: int(node.Port)}
 		go func() {
 			defer close(fallbackCh)
@@ -545,8 +550,8 @@ func (m *Memberlist) estNumNodes() int {
 }
 
 type ackMessage struct {
-	Complete bool
-	Payload  []byte
+	Complete  bool
+	Payload   []byte
 	Timestamp time.Time
 }
 


### PR DESCRIPTION
Not sure how you guys feel about this one, but it should make it easier for people to use Consul 0.6 without having to deal with mismatched protocol versions. If this is accepted, I'll bump Serf and Consul protocol versions back down.

This keeps memberlist speaking v2, but if the other side understands v3, it'll try TCP pings. I added a config option to turn off TCP pings since there was no other way to do that.