### PR TITLE
Log a debug message when a udp ping fails due to timeout

### DIFF
--- a/state.go
+++ b/state.go
@@ -246,6 +246,7 @@ func (m *Memberlist) probeNode(node *nodeState) {
 			ackCh <- v
 		}
 	case <-time.After(m.config.ProbeTimeout):
+		m.logger.Printf("[DEBUG] memberlist: Failed UDP ping: %v (timeout reached)", node.Name)
 	}
 
 	// Get some random live nodes.


### PR DESCRIPTION
This can be a helpful debug message when trying to find
misconfigurations of firewalls or EC2 security groups that cause udp
pings to occasionally fail. When a udp ping fails, that might indicate a
problem in configuration and having some debug message about it, with
the information about the node its trying to ping, can be useful in
finding the source of the failure.

This should help with ambiguous issues with flapping as found in
hashicorp/consul#1212.