### PR TITLE
Adding in the ability to use a custom logger in place of the default one

### DIFF
--- a/config.go
+++ b/config.go
@@ -135,11 +135,14 @@ type Config struct {
 	Merge                   MergeDelegate
 
 	// LogOutput is the writer where logs should be sent. If this is not
-	// set, logging will go to stderr by default.
+	// set, logging will go to stderr by default. You cannot specify both LogOutput
+	// and Logger at the same time.
 	LogOutput io.Writer
-	// Logger is a custom logger which you provide. If Logger is set, it will use this for
-	// the internal logger. If this is not set, it will fall back to the behavior for
-	// LogOutput is not set, logging will go to stderr by default.
+
+	// Logger is a custom logger which you provide. If Logger is set, it will use
+	// this for the internal logger. If Logger is not set, it will fall back to the
+	// behavior for using LogOutput. You cannot specify both LogOutput and Logger
+	// at the same time.
 	Logger *log.Logger
 }
 

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package memberlist
 
 import (
 	"io"
+	"log"
 	"os"
 	"time"
 )
@@ -136,6 +137,10 @@ type Config struct {
 	// LogOutput is the writer where logs should be sent. If this is not
 	// set, logging will go to stderr by default.
 	LogOutput io.Writer
+	// Logger is a custom logger which you provide. If Logger is set, it will use this for
+	// the internal logger. If this is not set, it will fall back to the behavior for
+	// LogOutput is not set, logging will go to stderr by default.
+	Logger *log.Logger
 }
 
 // DefaultLANConfig returns a sane set of configurations for Memberlist.

--- a/memberlist.go
+++ b/memberlist.go
@@ -104,7 +104,10 @@ func newMemberlist(conf *Config) (*Memberlist, error) {
 	if conf.LogOutput == nil {
 		conf.LogOutput = os.Stderr
 	}
-	logger := log.New(conf.LogOutput, "", log.LstdFlags)
+
+	if conf.Logger == nil {
+		conf.Logger = log.New(conf.LogOutput, "", log.LstdFlags)
+	}
 
 	m := &Memberlist{
 		config:         conf,
@@ -116,7 +119,7 @@ func newMemberlist(conf *Config) (*Memberlist, error) {
 		nodeMap:        make(map[string]*nodeState),
 		ackHandlers:    make(map[uint32]*ackHandler),
 		broadcasts:     &TransmitLimitedQueue{RetransmitMult: conf.RetransmitMult},
-		logger:         logger,
+		logger:         conf.Logger,
 	}
 	m.broadcasts.NumNodes = func() int { return len(m.nodes) }
 	go m.tcpListen()

--- a/memberlist.go
+++ b/memberlist.go
@@ -101,6 +101,10 @@ func newMemberlist(conf *Config) (*Memberlist, error) {
 	// Set the UDP receive window size
 	setUDPRecvBuf(udpLn)
 
+	if conf.LogOutput != nil && conf.Logger != nil {
+		return nil, fmt.Errorf("Cannot specify both LogOutput and Logger. Please choose a single log configuration setting.")
+	}
+
 	if conf.LogOutput == nil {
 		conf.LogOutput = os.Stderr
 	}

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -3,6 +3,7 @@ package memberlist
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net"
 	"reflect"
@@ -228,6 +229,17 @@ func TestCreate_keyringAndSecretKey(t *testing.T) {
 	ringKeys := c.Keyring.GetKeys()
 	if !bytes.Equal(c.SecretKey, ringKeys[0]) {
 		t.Fatalf("Unexpected primary key %v", ringKeys[0])
+	}
+}
+
+func TestCreate_invalidLoggerSettings(t *testing.T) {
+	c := DefaultLANConfig()
+	c.Logger = log.New(ioutil.Discard, "", log.LstdFlags)
+	c.LogOutput = ioutil.Discard
+
+	_, err := Create(c)
+	if err == nil {
+		t.Fatal("Memberlist should not allow both LogOutput and Logger to be set, but it did not raise an error")
 	}
 }
 


### PR DESCRIPTION
This is to address #39 

I figured since you already had the config abstraction, the best thing to do would be to layer this into the existing logoutput options, but to leave those in to maintain compatibility.