### PR TITLE
Only call the delegate with userBuf if it is not nil

### DIFF
--- a/net.go
+++ b/net.go
@@ -955,7 +955,7 @@ func (m *Memberlist) mergeRemoteState(join bool, remoteNodes []pushNodeState, us
 	m.mergeState(remoteNodes)
 
 	// Invoke the delegate for user state
-	if m.config.Delegate != nil {
+	if userBuf != nil && m.config.Delegate != nil{
 		m.config.Delegate.MergeRemoteState(userBuf, join)
 	}
 	return nil


### PR DESCRIPTION
Without this check if a pushPullMsg is sent with a UserStateLen of 0, userBuf is nill and passed to the delegates.

Issue over in serf: https://github.com/hashicorp/serf/issues/339