### PR TITLE
Keeps logger config options intact so we can re-use a config.

### DIFF
--- a/memberlist.go
+++ b/memberlist.go
@@ -107,12 +107,14 @@ func newMemberlist(conf *Config) (*Memberlist, error) {
 		return nil, fmt.Errorf("Cannot specify both LogOutput and Logger. Please choose a single log configuration setting.")
 	}
 
-	if conf.LogOutput == nil {
-		conf.LogOutput = os.Stderr
+	logDest := conf.LogOutput
+	if logDest == nil {
+		logDest = os.Stderr
 	}
 
-	if conf.Logger == nil {
-		conf.Logger = log.New(conf.LogOutput, "", log.LstdFlags)
+	logger := conf.Logger
+	if logger == nil {
+		logger = log.New(logDest, "", log.LstdFlags)
 	}
 
 	m := &Memberlist{
@@ -125,7 +127,7 @@ func newMemberlist(conf *Config) (*Memberlist, error) {
 		nodeMap:        make(map[string]*nodeState),
 		ackHandlers:    make(map[uint32]*ackHandler),
 		broadcasts:     &TransmitLimitedQueue{RetransmitMult: conf.RetransmitMult},
-		logger:         conf.Logger,
+		logger:         logger,
 	}
 	m.broadcasts.NumNodes = func() int {
 		return m.estNumNodes()


### PR DESCRIPTION
The change in https://github.com/hashicorp/memberlist/pull/56 ended up causing a small regression - https://travis-ci.org/hashicorp/consul/builds/95523949. The problem is that the operations at startup leave the config in a state that won't pass the sanity check the second time around. This PR keeps it from altering the config object when creating a logger, so the config can be reused multiple times. This probably affects unit tests and not real uses of memberlist, but it's bad to leave the config in an invalid state, so it's best fixed down here.