### PR TITLE
Fix resolution of IPv6 addresses

### DIFF
--- a/util.go
+++ b/util.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"math/rand"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-msgpack/codec"
@@ -324,6 +325,12 @@ func IsPrivateIP(ip_str string) bool {
 func isLoopbackIP(ip_str string) bool {
 	ip := net.ParseIP(ip_str)
 	return loopbackBlock.Contains(ip)
+}
+
+// Given a string of the form "host", "host:port", or "[ipv6::address]:port",
+// return true if the string includes a port.
+func hasPort(s string) bool {
+	return strings.LastIndex(s, ":") > strings.LastIndex(s, "]")
 }
 
 // compressPayload takes an opaque input buffer, compresses it


### PR DESCRIPTION
Previously `resolveAddr("[IPv6-addr]")` passed `[IPv6-addr]` to `net.ParseIP` and failed with `invalid domain name`.

`hasPort` utility comes from `net/http/client.go`.

This would fix `consul join "[IPv6-addr]"` and #63.