### PR TITLE
Adds a "self-awareness" feature that slows down the failure detector if a node is unhealthy.

### DIFF
--- a/awareness.go
+++ b/awareness.go
@@ -1,0 +1,52 @@
+package memberlist
+
+import (
+	"sync"
+	"time"
+)
+
+// awareness manages a simple metric for tracking the estimated health of the
+// local node. Health is primary the node's ability to respond in the soft
+// real-time manner required for correct health checking of other nodes in the
+// cluster.
+type awareness struct {
+	sync.RWMutex
+
+	// max is the upper threshold for the score (inclusive).
+	max int
+
+	// score is the current awareness score. Lower values are healthier and
+	// zero is the minimum value.
+	score int
+}
+
+// newAwareness returns a new awareness object.
+func newAwareness(max int) *awareness {
+	return &awareness{
+		max:   max,
+		score: 0,
+	}
+}
+
+// ApplyDelta takes the given delta and applies it to the score in a thread-safe
+// manner. It also enforces a floor of zero and a max of max, so deltas may not
+// change the overall score if it's railed at one of the extremes.
+func (a *awareness) ApplyDelta(delta int) {
+	a.Lock()
+	a.score += delta
+	if a.score < 0 {
+		a.score = 0
+	} else if a.score > a.max {
+		a.score = a.max
+	}
+	a.Unlock()
+}
+
+// ScaleTimeout takes the given duration and scales it based on the current
+// score. Less healthyness will lead to longer timeouts.
+func (a *awareness) ScaleTimeout(timeout time.Duration) time.Duration {
+	a.RLock()
+	score := a.score
+	a.RUnlock()
+	return timeout * (time.Duration(score) + 1)
+}

--- a/awareness.go
+++ b/awareness.go
@@ -14,7 +14,8 @@ import (
 type awareness struct {
 	sync.RWMutex
 
-	// max is the upper threshold for the score (inclusive).
+	// max is the upper threshold for the timeout scale (the score will be
+	// constrained to be from 0 <= score < max).
 	max int
 
 	// score is the current awareness score. Lower values are healthier and
@@ -39,8 +40,8 @@ func (a *awareness) ApplyDelta(delta int) {
 	a.score += delta
 	if a.score < 0 {
 		a.score = 0
-	} else if a.score > a.max {
-		a.score = a.max
+	} else if a.score > (a.max - 1) {
+		a.score = (a.max - 1)
 	}
 	final := a.score
 	a.Unlock()

--- a/awareness.go
+++ b/awareness.go
@@ -51,6 +51,14 @@ func (a *awareness) ApplyDelta(delta int) {
 	}
 }
 
+// GetHealthScore returns the raw health score.
+func (a *awareness) GetHealthScore() int {
+	a.RLock()
+	score := a.score
+	a.RUnlock()
+	return score
+}
+
 // ScaleTimeout takes the given duration and scales it based on the current
 // score. Less healthyness will lead to longer timeouts.
 func (a *awareness) ScaleTimeout(timeout time.Duration) time.Duration {

--- a/awareness_test.go
+++ b/awareness_test.go
@@ -30,7 +30,7 @@ func TestAwareness(t *testing.T) {
 	a := newAwareness(8)
 	for i, c := range cases {
 		a.ApplyDelta(c.delta)
-		if a.score != c.score {
+		if a.GetHealthScore() != c.score {
 			t.Errorf("case %d: score mismatch %d != %d", i, a.score, c.score)
 		}
 		if timeout := a.ScaleTimeout(1 * time.Second); timeout != c.timeout {

--- a/awareness_test.go
+++ b/awareness_test.go
@@ -1,0 +1,41 @@
+package memberlist
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAwareness(t *testing.T) {
+	cases := []struct {
+		delta   int
+		score   int
+		timeout time.Duration
+	}{
+		{0, 0, 1 * time.Second},
+		{-1, 0, 1 * time.Second},
+		{-10, 0, 1 * time.Second},
+		{1, 1, 2 * time.Second},
+		{-1, 0, 1 * time.Second},
+		{10, 7, 8 * time.Second},
+		{-1, 6, 7 * time.Second},
+		{-1, 5, 6 * time.Second},
+		{-1, 4, 5 * time.Second},
+		{-1, 3, 4 * time.Second},
+		{-1, 2, 3 * time.Second},
+		{-1, 1, 2 * time.Second},
+		{-1, 0, 1 * time.Second},
+		{-1, 0, 1 * time.Second},
+	}
+
+	a := newAwareness(7)
+	for i, c := range cases {
+		a.ApplyDelta(c.delta)
+		if a.score != c.score {
+			t.Errorf("case %d: score mismatch %d != %d", i, a.score, c.score)
+		}
+		if timeout := a.ScaleTimeout(1 * time.Second); timeout != c.timeout {
+			t.Errorf("case %d: scaled timeout mismatch %9.6f != %9.6f",
+				i, timeout.Seconds(), c.timeout.Seconds())
+		}
+	}
+}

--- a/awareness_test.go
+++ b/awareness_test.go
@@ -27,7 +27,7 @@ func TestAwareness(t *testing.T) {
 		{-1, 0, 1 * time.Second},
 	}
 
-	a := newAwareness(7)
+	a := newAwareness(8)
 	for i, c := range cases {
 		a.ApplyDelta(c.delta)
 		if a.score != c.score {

--- a/config.go
+++ b/config.go
@@ -205,7 +205,7 @@ func DefaultLANConfig() *Config {
 		ProbeTimeout:            500 * time.Millisecond, // Reasonable RTT time for LAN
 		ProbeInterval:           1 * time.Second,        // Failure check every second
 		DisableTcpPings:         false,                  // TCP pings are safe, even with mixed versions
-		AwarenessMaxMultiplier:  7,                      // Probe interval backs off to (7 + 1) seconds
+		AwarenessMaxMultiplier:  8,                      // Probe interval backs off to 8 seconds
 
 		GossipNodes:    3,                      // Gossip to 3 nodes
 		GossipInterval: 200 * time.Millisecond, // Gossip more rapidly

--- a/config.go
+++ b/config.go
@@ -108,6 +108,11 @@ type Config struct {
 	// indirect UDP pings.
 	DisableTcpPings bool
 
+	// AwarenessMaxMultiplier will increase the probe interval if the node
+	// becomes aware that it might be degraded and not meeting the soft real
+	// time requirements to reliably probe other nodes.
+	AwarenessMaxMultiplier int
+
 	// GossipInterval and GossipNodes are used to configure the gossip
 	// behavior of memberlist.
 	//
@@ -200,6 +205,7 @@ func DefaultLANConfig() *Config {
 		ProbeTimeout:            500 * time.Millisecond, // Reasonable RTT time for LAN
 		ProbeInterval:           1 * time.Second,        // Failure check every second
 		DisableTcpPings:         false,                  // TCP pings are safe, even with mixed versions
+		AwarenessMaxMultiplier:  7,                      // Probe interval backs off to (7 + 1) seconds
 
 		GossipNodes:    3,                      // Gossip to 3 nodes
 		GossipInterval: 200 * time.Millisecond, // Gossip more rapidly

--- a/memberlist.go
+++ b/memberlist.go
@@ -629,6 +629,13 @@ func (m *Memberlist) anyAlive() bool {
 	return false
 }
 
+// GetHealthScore gives this instance's idea of how well it is meeting the soft
+// real-time requirements of the protocol. Lower numbers are better, and zero
+// means "totally healthy".
+func (m *Memberlist) GetHealthScore() int {
+	return m.awareness.GetHealthScore()
+}
+
 // ProtocolVersion returns the protocol version currently in use by
 // this memberlist.
 func (m *Memberlist) ProtocolVersion() uint8 {

--- a/memberlist.go
+++ b/memberlist.go
@@ -47,6 +47,7 @@ type Memberlist struct {
 	nodes      []*nodeState          // Known nodes
 	nodeMap    map[string]*nodeState // Maps Addr.String() -> NodeState
 	nodeTimers map[string]*suspicion // Maps Addr.String() -> suspicion timer
+	awareness  *awareness
 
 	tickerLock sync.Mutex
 	tickers    []*time.Ticker
@@ -131,6 +132,7 @@ func newMemberlist(conf *Config) (*Memberlist, error) {
 		handoff:        make(chan msgHandoff, 1024),
 		nodeMap:        make(map[string]*nodeState),
 		nodeTimers:     make(map[string]*suspicion),
+		awareness:      newAwareness(conf.AwarenessMaxMultiplier),
 		ackHandlers:    make(map[uint32]*ackHandler),
 		broadcasts:     &TransmitLimitedQueue{RetransmitMult: conf.RetransmitMult},
 		logger:         logger,

--- a/net.go
+++ b/net.go
@@ -24,9 +24,15 @@ const (
 	// A memberlist speaking version 2 of the protocol will attempt
 	// to TCP ping another memberlist who understands version 3 or
 	// greater.
+	//
+	// Version 4 added support for nacks as part of indirect probes.
+	// A memberlist speaking version 2 of the protocol will expect
+	// nacks from another memberlist who understands version 4 or
+	// greater, and likewise nacks will be sent to memberlists who
+	// understand version 4 or greater.
 	ProtocolVersion2Compatible = 2
 
-	ProtocolVersionMax = 3
+	ProtocolVersionMax = 4
 )
 
 // messageType is an integer ID of a type of message that can be received
@@ -46,6 +52,7 @@ const (
 	userMsg // User mesg, not handled by us
 	compressMsg
 	encryptMsg
+	nackRespMsg
 )
 
 // compressionType is used to specify the compression algorithm
@@ -83,12 +90,20 @@ type indirectPingReq struct {
 	Target []byte
 	Port   uint16
 	Node   string
+	Nack   bool // true if we'd like a nack back
 }
 
 // ack response is sent for a ping
 type ackResp struct {
 	SeqNo   uint32
 	Payload []byte
+}
+
+// nack response is sent for an indirect ping when the pinger doesn't hear from
+// the ping-ee within the configured timeout. This lets the original node know
+// that the indirect ping attempt happened but didn't succeed.
+type nackResp struct {
+	SeqNo uint32
 }
 
 // suspect is broadcast when we suspect a node is dead
@@ -343,6 +358,8 @@ func (m *Memberlist) handleCommand(buf []byte, from net.Addr, timestamp time.Tim
 		m.handleIndirectPing(buf, from)
 	case ackRespMsg:
 		m.handleAck(buf, from, timestamp)
+	case nackRespMsg:
+		m.handleNack(buf, from)
 
 	case suspectMsg:
 		fallthrough
@@ -440,18 +457,23 @@ func (m *Memberlist) handleIndirectPing(buf []byte, from net.Addr) {
 	}
 
 	// For proto versions < 2, there is no port provided. Mask old
-	// behavior by using the configured port
+	// behavior by using the configured port.
 	if m.ProtocolVersion() < 2 || ind.Port == 0 {
 		ind.Port = uint16(m.config.BindPort)
 	}
 
-	// Send a ping to the correct host
+	// Send a ping to the correct host.
 	localSeqNo := m.nextSeqNo()
 	ping := ping{SeqNo: localSeqNo, Node: ind.Node}
 	destAddr := &net.UDPAddr{IP: ind.Target, Port: int(ind.Port)}
 
 	// Setup a response handler to relay the ack
+	cancelCh := make(chan struct{}, 1)
 	respHandler := func(payload []byte, timestamp time.Time) {
+		// Try to prevent the nack if we've caught it in time.
+		close(cancelCh)
+
+		// Forward the ack back to the requestor.
 		ack := ackResp{ind.SeqNo, nil}
 		if err := m.encodeAndSendMsg(from, ackRespMsg, &ack); err != nil {
 			m.logger.Printf("[ERR] memberlist: Failed to forward ack: %s %s", err, LogAddress(from))
@@ -459,9 +481,24 @@ func (m *Memberlist) handleIndirectPing(buf []byte, from net.Addr) {
 	}
 	m.setAckHandler(localSeqNo, respHandler, m.config.ProbeTimeout)
 
-	// Send the ping
+	// Send the ping.
 	if err := m.encodeAndSendMsg(destAddr, pingMsg, &ping); err != nil {
 		m.logger.Printf("[ERR] memberlist: Failed to send ping: %s %s", err, LogAddress(from))
+	}
+
+	// Setup a timer to fire off a nack if no ack is seen in time.
+	if ind.Nack {
+		go func() {
+			select {
+			case <-cancelCh:
+				return
+			case <-time.After(m.config.ProbeTimeout):
+				nack := nackResp{ind.SeqNo}
+				if err := m.encodeAndSendMsg(from, nackRespMsg, &nack); err != nil {
+					m.logger.Printf("[ERR] memberlist: Failed to send nack: %s %s", err, LogAddress(from))
+				}
+			}
+		}()
 	}
 }
 
@@ -472,6 +509,15 @@ func (m *Memberlist) handleAck(buf []byte, from net.Addr, timestamp time.Time) {
 		return
 	}
 	m.invokeAckHandler(ack, timestamp)
+}
+
+func (m *Memberlist) handleNack(buf []byte, from net.Addr) {
+	var nack nackResp
+	if err := decode(buf, &nack); err != nil {
+		m.logger.Printf("[ERR] memberlist: Failed to decode nack response: %s %s", err, LogAddress(from))
+		return
+	}
+	m.invokeNackHandler(nack)
 }
 
 func (m *Memberlist) handleSuspect(buf []byte, from net.Addr) {

--- a/net.go
+++ b/net.go
@@ -468,7 +468,7 @@ func (m *Memberlist) handleIndirectPing(buf []byte, from net.Addr) {
 	destAddr := &net.UDPAddr{IP: ind.Target, Port: int(ind.Port)}
 
 	// Setup a response handler to relay the ack
-	cancelCh := make(chan struct{}, 1)
+	cancelCh := make(chan struct{})
 	respHandler := func(payload []byte, timestamp time.Time) {
 		// Try to prevent the nack if we've caught it in time.
 		close(cancelCh)

--- a/state_test.go
+++ b/state_test.go
@@ -525,8 +525,8 @@ func TestMemberList_ProbeNode_Awareness_Degraded(t *testing.T) {
 
 	// Start the health in a degraded state.
 	m1.awareness.ApplyDelta(1)
-	if m1.awareness.score != 1 {
-		t.Fatalf("bad: %d", m1.awareness.score)
+	if score := m1.GetHealthScore(); score != 1 {
+		t.Fatalf("bad: %d", score)
 	}
 
 	// Have node m1 probe m4.
@@ -553,8 +553,8 @@ func TestMemberList_ProbeNode_Awareness_Degraded(t *testing.T) {
 
 	// We should have gotten all the nacks, so our score should remain the
 	// same, since we didn't get a successful probe.
-	if m1.awareness.score != 1 {
-		t.Fatalf("bad: %d", m1.awareness.score)
+	if score := m1.GetHealthScore(); score != 1 {
+		t.Fatalf("bad: %d", score)
 	}
 }
 
@@ -580,8 +580,8 @@ func TestMemberList_ProbeNode_Awareness_Improved(t *testing.T) {
 
 	// Start the health in a degraded state.
 	m1.awareness.ApplyDelta(1)
-	if m1.awareness.score != 1 {
-		t.Fatalf("bad: %d", m1.awareness.score)
+	if score := m1.GetHealthScore(); score != 1 {
+		t.Fatalf("bad: %d", score)
 	}
 
 	// Have node m1 probe m2.
@@ -594,8 +594,8 @@ func TestMemberList_ProbeNode_Awareness_Improved(t *testing.T) {
 	}
 
 	// Our score should have improved since we did a good probe.
-	if m1.awareness.score != 0 {
-		t.Fatalf("bad: %d", m1.awareness.score)
+	if score := m1.GetHealthScore(); score != 0 {
+		t.Fatalf("bad: %d", score)
 	}
 }
 
@@ -645,8 +645,8 @@ func TestMemberList_ProbeNode_Awareness_MissedNack(t *testing.T) {
 	m1.aliveNode(&a4, nil, false)
 
 	// Make sure health looks good.
-	if m1.awareness.score != 0 {
-		t.Fatalf("bad: %d", m1.awareness.score)
+	if score := m1.GetHealthScore(); score != 0 {
+		t.Fatalf("bad: %d", score)
 	}
 
 	// Have node m1 probe m4.
@@ -667,8 +667,8 @@ func TestMemberList_ProbeNode_Awareness_MissedNack(t *testing.T) {
 
 	// We should have gotten dinged for the missed nack.
 	time.Sleep(probeTimeMax)
-	if m1.awareness.score != 2 {
-		t.Fatalf("bad: %d", m1.awareness.score)
+	if score := m1.GetHealthScore(); score != 2 {
+		t.Fatalf("bad: %d", score)
 	}
 }
 
@@ -708,8 +708,8 @@ func TestMemberList_ProbeNode_Awareness_OldProtocol(t *testing.T) {
 	m1.aliveNode(&a4, nil, false)
 
 	// Make sure health looks good.
-	if m1.awareness.score != 0 {
-		t.Fatalf("bad: %d", m1.awareness.score)
+	if score := m1.GetHealthScore(); score != 0 {
+		t.Fatalf("bad: %d", score)
 	}
 
 	// Have node m1 probe m4.
@@ -736,8 +736,8 @@ func TestMemberList_ProbeNode_Awareness_OldProtocol(t *testing.T) {
 
 	// Since we are using the old protocol here, we should have gotten dinged
 	// for a failed health check.
-	if m1.awareness.score != 1 {
-		t.Fatalf("bad: %d", m1.awareness.score)
+	if score := m1.GetHealthScore(); score != 1 {
+		t.Fatalf("bad: %d", score)
 	}
 }
 
@@ -1330,8 +1330,8 @@ func TestMemberList_SuspectNode_Refute(t *testing.T) {
 	m.broadcasts.Reset()
 
 	// Make sure health is in a good state
-	if m.awareness.score != 0 {
-		t.Fatalf("bad: %d", m.awareness.score)
+	if score := m.GetHealthScore(); score != 0 {
+		t.Fatalf("bad: %d", score)
 	}
 
 	s := suspect{Node: m.config.Name, Incarnation: 1}
@@ -1353,8 +1353,8 @@ func TestMemberList_SuspectNode_Refute(t *testing.T) {
 	}
 
 	// Health should have been dinged
-	if m.awareness.score != 1 {
-		t.Fatalf("bad: %d", m.awareness.score)
+	if score := m.GetHealthScore(); score != 1 {
+		t.Fatalf("bad: %d", score)
 	}
 }
 
@@ -1489,8 +1489,8 @@ func TestMemberList_DeadNode_Refute(t *testing.T) {
 	m.broadcasts.Reset()
 
 	// Make sure health is in a good state
-	if m.awareness.score != 0 {
-		t.Fatalf("bad: %d", m.awareness.score)
+	if score := m.GetHealthScore(); score != 0 {
+		t.Fatalf("bad: %d", score)
 	}
 
 	d := dead{Node: m.config.Name, Incarnation: 1}
@@ -1512,8 +1512,8 @@ func TestMemberList_DeadNode_Refute(t *testing.T) {
 	}
 
 	// We should have been dinged
-	if m.awareness.score != 1 {
-		t.Fatalf("bad: %d", m.awareness.score)
+	if score := m.GetHealthScore(); score != 1 {
+		t.Fatalf("bad: %d", score)
 	}
 }
 


### PR DESCRIPTION
This uses several signals to slow down the failure detector if a node might not be meeting the soft real-time requirements of the protocol. Things that slow the detector down:

1. Failed probe if no peers support nacks
2. Missing nacks if the peers should support it
3. Having to refute a suspect or dead message

Things that speed the detector back up:

1. Successful probe of another node

We added nacks as part of this change, so a node can get feedback from an indirect probe, even if the node being probed is actually dead.