### PR TITLE
Adds a hint during a probe that a node is thought to be degraded.

### DIFF
--- a/util_test.go
+++ b/util_test.go
@@ -374,7 +374,8 @@ func TestDecodeCompoundMessage_Trunc(t *testing.T) {
 	msgs := [][]byte{buf.Bytes(), buf.Bytes(), buf.Bytes()}
 	compound := makeCompoundMessage(msgs)
 
-	trunc, parts, err := decodeCompoundMessage(compound.Bytes()[1:38])
+	bytes := compound.Bytes()
+	trunc, parts, err := decodeCompoundMessage(bytes[1 : len(bytes)-1])
 	if err != nil {
 		t.Fatalf("unexpected err: %s", err)
 	}


### PR DESCRIPTION
This allows the node being probed to immediately start gossiping a
refutation, rather than wait for an event to come in via gossip that
it can react to.