### PR TITLE
Add configuration option for UDP packet size

### DIFF
--- a/config.go
+++ b/config.go
@@ -184,6 +184,12 @@ type Config struct {
 	// size of this determines the size of the queue which Memberlist will keep
 	// while UDP messages are handled.
 	HandoffQueueDepth int
+
+	// Maximum number of bytes that memberlist expects UDP messages to be. A safe
+	// value for this is typically 1400 bytes (which is the default.) However,
+	// depending on your network's MTU (Maximum Transmission Unit) you may be able
+	// to increase this.
+	UDPBufferSize int
 }
 
 // DefaultLANConfig returns a sane set of configurations for Memberlist.
@@ -223,6 +229,7 @@ func DefaultLANConfig() *Config {
 		DNSConfigPath: "/etc/resolv.conf",
 
 		HandoffQueueDepth: 1024,
+		UDPBufferSize:     1400,
 	}
 }
 

--- a/net.go
+++ b/net.go
@@ -68,7 +68,6 @@ const (
 	compoundOverhead       = 2   // Assumed overhead per entry in compoundHeader
 	udpBufSize             = 65536
 	udpRecvBuf             = 2 * 1024 * 1024
-	udpSendBuf             = 1400
 	userMsgOverhead        = 1
 	blockingWarning        = 10 * time.Millisecond // Warn if a UDP packet takes this long to process
 	maxPushStateBytes      = 10 * 1024 * 1024
@@ -593,7 +592,7 @@ func (m *Memberlist) encodeAndSendMsg(to net.Addr, msgType messageType, msg inte
 // create a compoundMsg and piggy back other broadcasts
 func (m *Memberlist) sendMsg(to net.Addr, msg []byte) error {
 	// Check if we can piggy back any messages
-	bytesAvail := udpSendBuf - len(msg) - compoundHeaderOverhead
+	bytesAvail := m.config.UDPBufferSize - len(msg) - compoundHeaderOverhead
 	if m.config.EncryptionEnabled() {
 		bytesAvail -= encryptOverhead(m.encryptionVersion())
 	}

--- a/state.go
+++ b/state.go
@@ -467,7 +467,7 @@ func (m *Memberlist) gossip() {
 	m.nodeLock.RUnlock()
 
 	// Compute the bytes available
-	bytesAvail := udpSendBuf - compoundHeaderOverhead
+	bytesAvail := m.config.UDPBufferSize - compoundHeaderOverhead
 	if m.config.EncryptionEnabled() {
 		bytesAvail -= encryptOverhead(m.encryptionVersion())
 	}


### PR DESCRIPTION
Hello there!

This PR adds a configuration option, `UDPBufferSize`, that sets the expected size of UDP packets. 1400 is a completely reasonable default, but depending on the network that you're running Memberlist on, you may be able to safely set it higher. In my case, this is useful because the MTU is set to 9000, which ends up increasing throughput by about 6x. 

Let me know if there's anything I need to do to make this more acceptable. :)

Thanks.