### PR TITLE
gossip() should send a single message without compound message wrapper

### DIFF
--- a/state.go
+++ b/state.go
@@ -496,13 +496,19 @@ func (m *Memberlist) gossip() {
 			return
 		}
 
-		// Create a compound message
-		compound := makeCompoundMessage(msgs)
-
-		// Send the compound message
 		destAddr := &net.UDPAddr{IP: node.Addr, Port: int(node.Port)}
-		if err := m.rawSendMsgUDP(destAddr, &node.Node, compound.Bytes()); err != nil {
-			m.logger.Printf("[ERR] memberlist: Failed to send gossip to %s: %s", destAddr, err)
+
+		if len(msgs) == 1 {
+			// Send single message as is
+			if err := m.rawSendMsgUDP(destAddr, &node.Node, msgs[0]); err != nil {
+				m.logger.Printf("[ERR] memberlist: Failed to send gossip to %s: %s", destAddr, err)
+			}
+		} else {
+			// Otherwise create and send a compound message
+			compound := makeCompoundMessage(msgs)
+			if err := m.rawSendMsgUDP(destAddr, &node.Node, compound.Bytes()); err != nil {
+				m.logger.Printf("[ERR] memberlist: Failed to send gossip to %s: %s", destAddr, err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
`makeCompoundMessage()` should only be called when there are multiple messages to send together. `sendMsg` and `probeNode()` correctly guard for this, but `gossip()` currently does not.

Note that no unit test change accompanies this fix, as there does not appear to be a unit test that can detect this difference, or a way to add one without intrusively modifying the methods in this area. The fix was tested by temporarily inserting additional logging and running on a 100 node instance of Consul, with injected anomalies. The single message code path was observed to be taken around 55% of the time.