### PR TITLE
reduce NACK influence

### DIFF
--- a/state.go
+++ b/state.go
@@ -390,7 +390,7 @@ func (m *Memberlist) probeNode(node *nodeState) {
 	awarenessDelta = 0
 	if expectedNacks > 0 {
 		if nackCount := len(nackCh); nackCount < expectedNacks {
-			awarenessDelta += 2 * (expectedNacks - nackCount)
+			awarenessDelta += (expectedNacks - nackCount)
 		}
 	} else {
 		awarenessDelta += 1


### PR DESCRIPTION
Lifeguard introduced Self-Awareness, with an awareness delta that is in
part based on the difference between the expected and actual NACKs
received. A multiplier of 2 was used on this value. Benchmarking
indicates this may start to become counterproductive at very high
numbers of concurrent anomalies, so lets remove the multiplier.