### PR TITLE
Fix error return from go vet failure

### DIFF
--- a/memberlist.go
+++ b/memberlist.go
@@ -334,7 +334,7 @@ func (m *Memberlist) setAlive() error {
 	addr, port, err := m.transport.FinalAdvertiseAddr(
 		m.config.AdvertiseAddr, m.config.AdvertisePort)
 	if err != nil {
-		return fmt.Errorf("Failed to get final advertise address: %v")
+		return fmt.Errorf("Failed to get final advertise address: %v", err)
 	}
 
 	// Check if this is a public address without encryption


### PR DESCRIPTION
Fixes error return in `setAlive()` func.

Fixes: #116