### PR TITLE
Add String() method to Node type

### DIFF
--- a/state.go
+++ b/state.go
@@ -40,6 +40,11 @@ func (n *Node) Address() string {
 	return joinHostPort(n.Addr.String(), n.Port)
 }
 
+// String returns the node name
+func (n *Node) String() string {
+	return n.Name
+}
+
 // NodeState is used to manage our state view of another node
 type nodeState struct {
 	Node


### PR DESCRIPTION
So that we can easily print an identifier for a node, e.g. in logs.

This also means that you can use `list.Members()` in a printf statement
and get a human-readable list of members, e.g.:

    [foo,bar,baz]