### PR TITLE
Add config settings for supporting gossip upshift

### DIFF
--- a/config.go
+++ b/config.go
@@ -141,6 +141,16 @@ type Config struct {
 	GossipNodes         int
 	GossipToTheDeadTime time.Duration
 
+	// GossipVerifyIncoming controls whether to enforce encryption for incoming
+	// gossip. It is used for upshifting from unencrypted to encrypted gossip on
+	// a running cluster.
+	GossipVerifyIncoming bool
+
+	// GossipVerifyOutgoing controls whether to enforce encryption for outgoing
+	// gossip. It is used for upshifting from unencrypted to encrypted gossip on
+	// a running cluster.
+	GossipVerifyOutgoing bool
+
 	// EnableCompression is used to control message compression. This can
 	// be used to reduce bandwidth usage at the cost of slightly more CPU
 	// utilization. This is only available starting at protocol version 1.
@@ -233,9 +243,11 @@ func DefaultLANConfig() *Config {
 		DisableTcpPings:         false,                  // TCP pings are safe, even with mixed versions
 		AwarenessMaxMultiplier:  8,                      // Probe interval backs off to 8 seconds
 
-		GossipNodes:         3,                      // Gossip to 3 nodes
-		GossipInterval:      200 * time.Millisecond, // Gossip more rapidly
-		GossipToTheDeadTime: 30 * time.Second,       // Same as push/pull
+		GossipNodes:          3,                      // Gossip to 3 nodes
+		GossipInterval:       200 * time.Millisecond, // Gossip more rapidly
+		GossipToTheDeadTime:  30 * time.Second,       // Same as push/pull
+		GossipVerifyIncoming: true,
+		GossipVerifyOutgoing: true,
 
 		EnableCompression: true, // Enable compression by default
 

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -1321,6 +1321,129 @@ func TestMemberlist_PingDelegate(t *testing.T) {
 	}
 }
 
+func TestMemberlist_EncryptedGossipTransition(t *testing.T) {
+	m1 := GetMemberlist(t)
+	m1.setAlive()
+	m1.schedule()
+	defer m1.Shutdown()
+
+	// Create a second node with the first stage of gossip transition settings
+	conf2 := DefaultLANConfig()
+	addr2 := getBindAddr()
+	conf2.Name = addr2.String()
+	conf2.BindAddr = addr2.String()
+	conf2.BindPort = m1.config.BindPort
+	conf2.GossipInterval = time.Millisecond
+	conf2.SecretKey = []byte("Hi16ZXu2lNCRVwtr20khAg==")
+	conf2.GossipVerifyIncoming = false
+	conf2.GossipVerifyOutgoing = false
+
+	m2, err := Create(conf2)
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+	defer m2.Shutdown()
+
+	// Join the second node. m1 has no encryption while m2 has encryption configured and
+	// can receive encrypted gossip, but will not encrypt outgoing gossip.
+	num, err := m2.Join([]string{m1.config.BindAddr})
+	if num != 1 {
+		t.Fatalf("unexpected 1: %d", num)
+	}
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+
+	// Check the hosts
+	if len(m2.Members()) != 2 {
+		t.Fatalf("should have 2 nodes! %v", m2.Members())
+	}
+	if m2.estNumNodes() != 2 {
+		t.Fatalf("should have 2 nodes! %v", m2.Members())
+	}
+
+	// Leave with the first node
+	m1.Leave(time.Second)
+
+	// Wait for leave
+	time.Sleep(10 * time.Millisecond)
+
+	// Create a third node that has the second stage of gossip transition settings
+	conf3 := DefaultLANConfig()
+	addr3 := getBindAddr()
+	conf3.Name = addr3.String()
+	conf3.BindAddr = addr3.String()
+	conf3.BindPort = m1.config.BindPort
+	conf3.GossipInterval = time.Millisecond
+	conf3.SecretKey = conf2.SecretKey
+	conf3.GossipVerifyIncoming = false
+
+	m3, err := Create(conf3)
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+	defer m3.Shutdown()
+
+	// Join the second node to the third node. At this step, both nodes have encryption
+	// configured but only m3 is sending encrypted gossip.
+	num, err = m3.Join([]string{m2.config.BindAddr})
+	if num != 1 {
+		t.Fatalf("unexpected 1: %d", num)
+	}
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+
+	// Check the hosts
+	if len(m3.Members()) != 2 {
+		t.Fatalf("should have 2 nodes! %v", m3.Members())
+
+	}
+	if m3.estNumNodes() != 2 {
+		t.Fatalf("should have 2 nodes! %v", m3.Members())
+	}
+
+	// Leave with the second node
+	m2.Leave(time.Second)
+
+	// Wait for leave
+	time.Sleep(10 * time.Millisecond)
+
+	// Create a fourth node that has the second stage of gossip transition settings
+	conf4 := DefaultLANConfig()
+	addr4 := getBindAddr()
+	conf4.Name = addr4.String()
+	conf4.BindAddr = addr4.String()
+	conf4.BindPort = m3.config.BindPort
+	conf4.GossipInterval = time.Millisecond
+	conf4.SecretKey = conf2.SecretKey
+
+	m4, err := Create(conf4)
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+	defer m4.Shutdown()
+
+	// Join the second node to the third node. At this step, both m3 and m4 are speaking
+	// encrypted gossip and m3 is still accepting insecure gossip.
+	num, err = m4.Join([]string{m3.config.BindAddr})
+	if num != 1 {
+		t.Fatalf("unexpected 1: %d", num)
+	}
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+
+	// Check the hosts
+	if len(m4.Members()) != 2 {
+		t.Fatalf("should have 2 nodes! %v", m4.Members())
+
+	}
+	if m4.estNumNodes() != 2 {
+		t.Fatalf("should have 2 nodes! %v", m4.Members())
+	}
+}
+
 // Consul bug, rapid restart (before failure detection),
 // with an updated meta data. Should be at incarnation 1 for
 // both.

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -1384,7 +1384,7 @@ func TestMemberlist_EncryptedGossipTransition(t *testing.T) {
 	}
 	defer m3.Shutdown()
 
-	// Join the second node to the third node. At this step, both nodes have encryption
+	// Join the third node to the second node. At this step, both nodes have encryption
 	// configured but only m3 is sending encrypted gossip.
 	num, err = m3.Join([]string{m2.config.BindAddr})
 	if num != 1 {
@@ -1424,7 +1424,7 @@ func TestMemberlist_EncryptedGossipTransition(t *testing.T) {
 	}
 	defer m4.Shutdown()
 
-	// Join the second node to the third node. At this step, both m3 and m4 are speaking
+	// Join the fourth node to the third node. At this step, both m3 and m4 are speaking
 	// encrypted gossip and m3 is still accepting insecure gossip.
 	num, err = m4.Join([]string{m3.config.BindAddr})
 	if num != 1 {


### PR DESCRIPTION
Adds the `GossipVerifyIncoming` and `GossipVerifyOutgoing` settings to enable upshifting to encrypted gossip on a running cluster.