### PR TITLE
Sets the advertise port as well in auto port mode and adds bind retries.

### DIFF
--- a/memberlist.go
+++ b/memberlist.go
@@ -121,6 +121,7 @@ func newMemberlist(conf *Config) (*Memberlist, error) {
 		if conf.BindPort == 0 {
 			port := nt.GetAutoBindPort()
 			conf.BindPort = port
+			conf.AdvertisePort = port
 			logger.Printf("[DEBUG] Using dynamic bind port %d", port)
 		}
 		transport = nt

--- a/memberlist.go
+++ b/memberlist.go
@@ -113,11 +113,39 @@ func newMemberlist(conf *Config) (*Memberlist, error) {
 			BindPort:  conf.BindPort,
 			Logger:    logger,
 		}
-		nt, err := NewNetTransport(nc)
+
+		// See comment below for details about the retry in here.
+		makeNetRetry := func(limit int) (*NetTransport, error) {
+			for try := 0; try < limit; try++ {
+				nt, err := NewNetTransport(nc)
+				if err == nil {
+					return nt, nil
+				}
+
+				if strings.Contains(err.Error(), "address already in use") {
+					logger.Printf("[DEBUG] Got bind error: %v", err)
+					continue
+				}
+			}
+
+			return nil, fmt.Errorf("ran out of tries to obtain an address")
+		}
+
+		// The dynamic bind port operation is inherently racy because
+		// even though we are using the kernel to find a port for us, we
+		// are attempting to bind multiple protocols (and potentially
+		// multiple addresses) with the same port number. We build in a
+		// few retries here since this often gets transient errors in
+		// busy unit tests.
+		limit := 1
+		if conf.BindPort == 0 {
+			limit = 10
+		}
+
+		nt, err := makeNetRetry(limit)
 		if err != nil {
 			return nil, fmt.Errorf("Could not set up network transport: %v", err)
 		}
-
 		if conf.BindPort == 0 {
 			port := nt.GetAutoBindPort()
 			conf.BindPort = port


### PR DESCRIPTION
This is required because the advertise port is what is placed in the memberlist and shared with the rest of the cluster. Since we are auto picking the port we need to set that as well. See https://github.com/hashicorp/memberlist/blob/v0.1.0/memberlist.go#L332-L338.

Also, even though we are using the kernel to pick a port, we require TCP and UDP to get the same port number, so it's still racy when setting a 0 bind port for auto port mode. We put a retry loop which will attempt another round of auto port selection (up to 10 tries) if this happens. This isn't great, but this is mostly used in unit tests, and that's where we see this running many instances in parallel (esp. in Consul).