### PR TITLE
Moves the RTT start time capture before I/O.

### DIFF
--- a/state.go
+++ b/state.go
@@ -251,10 +251,17 @@ func (m *Memberlist) probeNode(node *nodeState) {
 	nackCh := make(chan struct{}, m.config.IndirectChecks+1)
 	m.setProbeChannels(ping.SeqNo, ackCh, nackCh, probeInterval)
 
+	// Mark the sent time here, which should be after any pre-processing but
+	// before system calls to do the actual send. This probably over-reports
+	// a bit, but it's the best we can do. We had originally put this right
+	// after the I/O, but that would sometimes give negative RTT measurements
+	// which was not desirable.
+	sent := time.Now()
+
 	// Send a ping to the node. If this node looks like it's suspect or dead,
 	// also tack on a suspect message so that it has a chance to refute as
 	// soon as possible.
-	deadline := time.Now().Add(probeInterval)
+	deadline := sent.Add(probeInterval)
 	addr := node.Address()
 	if node.State == stateAlive {
 		if err := m.encodeAndSendMsg(addr, pingMsg, &ping); err != nil {
@@ -283,11 +290,6 @@ func (m *Memberlist) probeNode(node *nodeState) {
 			return
 		}
 	}
-
-	// Mark the sent time here, which should be after any pre-processing and
-	// system calls to do the actual send. This probably under-reports a bit,
-	// but it's the best we can do.
-	sent := time.Now()
 
 	// Arrange for our self-awareness to get updated. At this point we've
 	// sent the ping, so any return statement means the probe succeeded


### PR DESCRIPTION
Before this was doing it right after, but if a machine is super busy we can see negative round trip time estimates, which is bad for the Vivaldi algorithm. The rationale before was it was trying to get as close as possible to the I/O, but that wasn't a good assumption.