### PR TITLE
Calculates the timeout for dial using the deadline.

### DIFF
--- a/memberlist.go
+++ b/memberlist.go
@@ -639,7 +639,9 @@ func (m *Memberlist) Shutdown() error {
 	// Shut down the transport first, which should block until it's
 	// completely torn down. If we kill the memberlist-side handlers
 	// those I/O handlers might get stuck.
-	m.transport.Shutdown()
+	if err := m.transport.Shutdown(); err != nil {
+		m.logger.Printf("[ERR] Failed to shutdown transport: %v", err)
+	}
 
 	// Now tear down everything else.
 	atomic.StoreInt32(&m.shutdown, 1)

--- a/net.go
+++ b/net.go
@@ -1059,7 +1059,7 @@ func (m *Memberlist) readUserMsg(bufConn io.Reader, dec *codec.Decoder) error {
 // operations, given the deadline. The bool return parameter is true if we
 // we able to round trip a ping to the other node.
 func (m *Memberlist) sendPingAndWaitForAck(addr string, ping ping, deadline time.Time) (bool, error) {
-	conn, err := m.transport.DialTimeout(addr, m.config.TCPTimeout)
+	conn, err := m.transport.DialTimeout(addr, deadline.Sub(time.Now()))
 	if err != nil {
 		// If the node is actually dead we expect this to fail, so we
 		// shouldn't spam the logs with it. After this point, errors


### PR DESCRIPTION
Before this change we could wait up to 10 seconds (the LAN TCP timeout) for the dial to complete, which could hold up pings and violates the contract of the deadline.

While we were in here debugging we added some logging if the transport gets an error while shutting down.