### PR TITLE
Integrate hclog

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -52,7 +52,7 @@ func (m *Memberlist) encodeAndBroadcast(node string, msgType messageType, msg in
 func (m *Memberlist) encodeBroadcastNotify(node string, msgType messageType, msg interface{}, notify chan struct{}) {
 	buf, err := encode(msgType, msg)
 	if err != nil {
-		m.logger.Printf("[ERR] memberlist: Failed to encode message for broadcast: %s", err)
+		m.logger.Error("Failed to encode message for broadcast", "err", err)
 	} else {
 		m.queueBroadcast(node, buf.Bytes(), notify)
 	}

--- a/config.go
+++ b/config.go
@@ -1,10 +1,10 @@
 package memberlist
 
 import (
-	"io"
-	"log"
 	"os"
 	"time"
+
+	hclog "github.com/hashicorp/go-hclog"
 )
 
 type Config struct {
@@ -191,16 +191,8 @@ type Config struct {
 	// at /etc/resolv.conf. It can be overridden via config for easier testing.
 	DNSConfigPath string
 
-	// LogOutput is the writer where logs should be sent. If this is not
-	// set, logging will go to stderr by default. You cannot specify both LogOutput
-	// and Logger at the same time.
-	LogOutput io.Writer
-
-	// Logger is a custom logger which you provide. If Logger is set, it will use
-	// this for the internal logger. If Logger is not set, it will fall back to the
-	// behavior for using LogOutput. You cannot specify both LogOutput and Logger
-	// at the same time.
-	Logger *log.Logger
+	// Logger to use. If no value is passed, the default logger will be used.
+	Logger hclog.Logger
 
 	// Size of Memberlist's internal channel which handles UDP messages. The
 	// size of this determines the size of the queue which Memberlist will keep

--- a/logging.go
+++ b/logging.go
@@ -1,22 +1,27 @@
 package memberlist
 
 import (
-	"fmt"
 	"net"
+
+	hclog "github.com/hashicorp/go-hclog"
 )
 
-func LogAddress(addr net.Addr) string {
-	if addr == nil {
-		return "from=<unknown address>"
-	}
+const unknownAddr = "<unknown address>"
 
-	return fmt.Sprintf("from=%s", addr.String())
+type logger struct {
+	hclog.Logger
 }
 
-func LogConn(conn net.Conn) string {
-	if conn == nil {
-		return LogAddress(nil)
+func (l logger) fromAddress(addr net.Addr) logger {
+	if addr == nil {
+		return logger{Logger: l.With("from", unknownAddr)}
 	}
+	return logger{Logger: l.With("from", addr.String())}
+}
 
-	return LogAddress(conn.RemoteAddr())
+func (l logger) fromConn(conn net.Conn) logger {
+	if conn == nil {
+		return l.fromAddress(nil)
+	}
+	return l.fromAddress(conn.RemoteAddr())
 }

--- a/logging_test.go
+++ b/logging_test.go
@@ -2,14 +2,63 @@ package memberlist
 
 import (
 	"fmt"
+	"log"
 	"net"
+	"strings"
 	"testing"
+
+	hclog "github.com/hashicorp/go-hclog"
 )
 
+type recorder struct {
+	entry *string
+	args  []interface{}
+}
+
+func (r *recorder) add(msgType, msg string, args ...interface{}) {
+	argsStr := ""
+	for i := 0; i < len(args); i = i + 2 {
+		argsStr = argsStr + fmt.Sprintf("%v=%v", args[i], args[i+1])
+	}
+	for i := 0; i < len(r.args); i = i + 2 {
+		argsStr = argsStr + fmt.Sprintf("%v=%v", r.args[i], r.args[i+1])
+	}
+	entry := fmt.Sprintf("%s: %s %s", msgType, msg, argsStr)
+	*r.entry = entry
+}
+
+func (r *recorder) Trace(msg string, args ...interface{}) { r.add("trace", msg, args...) }
+func (r *recorder) Debug(msg string, args ...interface{}) { r.add("debug", msg, args...) }
+func (r *recorder) Info(msg string, args ...interface{})  { r.add("info", msg, args...) }
+func (r *recorder) Warn(msg string, args ...interface{})  { r.add("warn", msg, args...) }
+func (r *recorder) Error(msg string, args ...interface{}) { r.add("error", msg, args...) }
+
+func (r *recorder) IsTrace() bool { panic("not implemented") }
+func (r *recorder) IsDebug() bool { panic("not implemented") }
+func (r *recorder) IsInfo() bool  { panic("not implemented") }
+func (r *recorder) IsWarn() bool  { panic("not implemented") }
+func (r *recorder) IsError() bool { panic("not implemented") }
+
+func (r *recorder) With(args ...interface{}) hclog.Logger {
+	return &recorder{
+		entry: r.entry,
+		args:  append(r.args, args...),
+	}
+}
+
+func (r *recorder) Named(name string) hclog.Logger      { panic("not implemented") }
+func (r *recorder) ResetNamed(name string) hclog.Logger { panic("not implemented") }
+func (r *recorder) StandardLogger(opts *hclog.StandardLoggerOptions) *log.Logger {
+	panic("not implemented")
+}
+
 func TestLogging_Address(t *testing.T) {
-	s := LogAddress(nil)
-	if s != "from=<unknown address>" {
-		t.Fatalf("bad: %s", s)
+	r := &recorder{entry: new(string)}
+	l := logger{Logger: r}
+
+	l.fromAddress(nil).Info("Hello world")
+	if !strings.Contains(*r.entry, "from=<unknown address>") {
+		t.Fatalf("log entry does not contain from=<unknown address>: %s", *r.entry)
 	}
 
 	addr, err := net.ResolveIPAddr("ip4", "127.0.0.1")
@@ -17,16 +66,19 @@ func TestLogging_Address(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	s = LogAddress(addr)
-	if s != "from=127.0.0.1" {
-		t.Fatalf("bad: %s", s)
+	l.fromAddress(addr).Info("Hello world")
+	if !strings.Contains(*r.entry, "from=127.0.0.1") {
+		t.Fatalf("log entry does not contain the origin IP: %s", *r.entry)
 	}
 }
 
 func TestLogging_Conn(t *testing.T) {
-	s := LogConn(nil)
-	if s != "from=<unknown address>" {
-		t.Fatalf("bad: %s", s)
+	r := &recorder{entry: new(string)}
+	l := logger{Logger: r}
+
+	l.fromConn(nil).Info("Hello world")
+	if !strings.Contains(*r.entry, "from=<unknown address>") {
+		t.Fatalf("log entry does not contain from=<unknown address>: %s", *r.entry)
 	}
 
 	ln, err := net.Listen("tcp", ":0")
@@ -40,8 +92,8 @@ func TestLogging_Conn(t *testing.T) {
 	}
 	defer conn.Close()
 
-	s = LogConn(conn)
-	if s != fmt.Sprintf("from=%s", conn.RemoteAddr().String()) {
-		t.Fatalf("bad: %s", s)
+	l.fromConn(conn).Info("Hello world")
+	if !strings.Contains(*r.entry, fmt.Sprintf("from=%s", conn.RemoteAddr().String())) {
+		t.Fatalf("log entry does not contain the origin IP: %s", *r.entry)
 	}
 }

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/miekg/dns"
 )
 
@@ -238,8 +239,7 @@ func TestCreate_keyringAndSecretKey(t *testing.T) {
 func TestCreate_invalidLoggerSettings(t *testing.T) {
 	c := DefaultLANConfig()
 	c.BindAddr = getBindAddr().String()
-	c.Logger = log.New(ioutil.Discard, "", log.LstdFlags)
-	c.LogOutput = ioutil.Discard
+	c.Logger = hclog.NewNullLogger()
 
 	_, err := Create(c)
 	if err == nil {

--- a/net_test.go
+++ b/net_test.go
@@ -5,13 +5,13 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-msgpack/codec"
 )
 
@@ -777,8 +777,9 @@ func TestIngestPacket_CRC(t *testing.T) {
 	in[1] <<= 1
 
 	logs := &bytes.Buffer{}
-	logger := log.New(logs, "", 0)
-	m.logger = logger
+	m.logger = logger{Logger: hclog.New(&hclog.LoggerOptions{
+		Output: logs,
+	})}
 	m.ingestPacket(in, udp.LocalAddr(), time.Now())
 
 	if !strings.Contains(logs.String(), "invalid checksum") {


### PR DESCRIPTION
With this pull request, `memberlist` uses `hclog.Logger` as logging interface.

Here are a few other changes that this commit integrates:
+ The `Config` and `NetTransportConfig` are changed, and now take directly the `hclog.Logger` object. If no object is passed, `newMemberlist` uses `hclog.Default()`.
+ `fromAddress` and `fromConn` are now methods of a struct that embeds `hclog.Logger`.
    + Given that the way those methods are called has changed, tests have also changed.
+ To log errors, I drew inspiration from other projects using `hclog` and added them with the `"err"` field name.