### PR TITLE
Prioritize alive message over other messages

### DIFF
--- a/net.go
+++ b/net.go
@@ -395,16 +395,16 @@ func (m *Memberlist) handleCommand(buf []byte, from net.Addr, timestamp time.Tim
 	}
 }
 
-// getNextMessage returns the next message to process in priority order
+// getNextMessage returns the next message to process in priority order, using LIFO
 func (m *Memberlist) getNextMessage() (msgHandoff, bool) {
 	m.msgQueueLock.Lock()
 	defer m.msgQueueLock.Unlock()
 
-	if el := m.highPriorityMsgQueue.Front(); el != nil {
+	if el := m.highPriorityMsgQueue.Back(); el != nil {
 		m.highPriorityMsgQueue.Remove(el)
 		msg := el.Value.(msgHandoff)
 		return msg, true
-	} else if el := m.lowPriorityMsgQueue.Front(); el != nil {
+	} else if el := m.lowPriorityMsgQueue.Back(); el != nil {
 		m.lowPriorityMsgQueue.Remove(el)
 		msg := el.Value.(msgHandoff)
 		return msg, true

--- a/net.go
+++ b/net.go
@@ -369,15 +369,47 @@ func (m *Memberlist) handleCommand(buf []byte, from net.Addr, timestamp time.Tim
 	case deadMsg:
 		fallthrough
 	case userMsg:
-		select {
-		case m.handoff <- msgHandoff{msgType, buf, from}:
-		default:
+		// Determine the message queue, prioritize alive
+		queue := m.lowPriorityMsgQueue
+		if msgType == aliveMsg {
+			queue = m.highPriorityMsgQueue
+		}
+
+		// Check for overflow and append if not full
+		m.msgQueueLock.Lock()
+		if queue.Len() >= m.config.HandoffQueueDepth {
 			m.logger.Printf("[WARN] memberlist: handler queue full, dropping message (%d) %s", msgType, LogAddress(from))
+		} else {
+			queue.PushBack(msgHandoff{msgType, buf, from})
+		}
+		m.msgQueueLock.Unlock()
+
+		// Notify of pending message
+		select {
+		case m.handoffCh <- struct{}{}:
+		default:
 		}
 
 	default:
 		m.logger.Printf("[ERR] memberlist: msg type (%d) not supported %s", msgType, LogAddress(from))
 	}
+}
+
+// getNextMessage returns the next message to process in priority order
+func (m *Memberlist) getNextMessage() (msgHandoff, bool) {
+	m.msgQueueLock.Lock()
+	defer m.msgQueueLock.Unlock()
+
+	if el := m.highPriorityMsgQueue.Front(); el != nil {
+		m.highPriorityMsgQueue.Remove(el)
+		msg := el.Value.(msgHandoff)
+		return msg, true
+	} else if el := m.lowPriorityMsgQueue.Front(); el != nil {
+		m.lowPriorityMsgQueue.Remove(el)
+		msg := el.Value.(msgHandoff)
+		return msg, true
+	}
+	return msgHandoff{}, false
 }
 
 // packetHandler is a long running goroutine that processes messages received
@@ -386,22 +418,28 @@ func (m *Memberlist) handleCommand(buf []byte, from net.Addr, timestamp time.Tim
 func (m *Memberlist) packetHandler() {
 	for {
 		select {
-		case msg := <-m.handoff:
-			msgType := msg.msgType
-			buf := msg.buf
-			from := msg.from
+		case <-m.handoffCh:
+			for {
+				msg, ok := m.getNextMessage()
+				if !ok {
+					break
+				}
+				msgType := msg.msgType
+				buf := msg.buf
+				from := msg.from
 
-			switch msgType {
-			case suspectMsg:
-				m.handleSuspect(buf, from)
-			case aliveMsg:
-				m.handleAlive(buf, from)
-			case deadMsg:
-				m.handleDead(buf, from)
-			case userMsg:
-				m.handleUser(buf, from)
-			default:
-				m.logger.Printf("[ERR] memberlist: Message type (%d) not supported %s (packet handler)", msgType, LogAddress(from))
+				switch msgType {
+				case suspectMsg:
+					m.handleSuspect(buf, from)
+				case aliveMsg:
+					m.handleAlive(buf, from)
+				case deadMsg:
+					m.handleDead(buf, from)
+				case userMsg:
+					m.handleUser(buf, from)
+				default:
+					m.logger.Printf("[ERR] memberlist: Message type (%d) not supported %s (packet handler)", msgType, LogAddress(from))
+				}
 			}
 
 		case <-m.shutdownCh:

--- a/net.go
+++ b/net.go
@@ -1144,7 +1144,7 @@ func (m *Memberlist) sendPingAndWaitForAck(addr string, ping ping, deadline time
 	}
 
 	if ack.SeqNo != ping.SeqNo {
-		return false, fmt.Errorf("Sequence number from ack (%d) doesn't match ping (%d)", ack.SeqNo, ping.SeqNo, LogConn(conn))
+		return false, fmt.Errorf("Sequence number from ack (%d) doesn't match ping (%d)", ack.SeqNo, ping.SeqNo)
 	}
 
 	return true, nil

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,9 +1,10 @@
 package memberlist
 
 import (
-	"bytes"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestTransport_Join(t *testing.T) {
@@ -116,9 +117,13 @@ func TestTransport_Send(t *testing.T) {
 	}
 	time.Sleep(100 * time.Millisecond)
 
-	received := bytes.Join(d1.msgs, []byte("|"))
-	expected := []byte("SendTo|SendToUDP|SendToTCP|SendBestEffort|SendReliable")
-	if !bytes.Equal(received, expected) {
-		t.Fatalf("bad: %s", received)
+	expected := []string{"SendTo", "SendToUDP", "SendToTCP", "SendBestEffort", "SendReliable"}
+
+	received := make([]string, len(d1.msgs))
+	for i, bs := range d1.msgs {
+		received[i] = string(bs)
 	}
+	// Some of these are UDP so often get re-ordered making the test flaky if we
+	// assert send ordering. Sort both slices to be tolerant of re-ordering.
+	require.ElementsMatch(t, expected, received)
 }


### PR DESCRIPTION
This PR modifies the way UDP messages are handled to add message priorities. Previously, all messages would be decoded and added FIFO to the handoff queue. Under high pressure, delayed message processing can cause flapping in the cluster. By prioritizing alive messages we minimize the churn by ensuring timely processing and allowing us to ignore older suspect / dead messages.

We add two linked lists, a low and high priority queue. Each queue is LIFO, and we always check the high priority queue for work first. LIFO ordering is preferred to ensure more recent messages are processed first when there is slow processing to avoid churn.

Depends on #158 