### PR TITLE
Improve the experience of running tests

### DIFF
--- a/net_test.go
+++ b/net_test.go
@@ -647,6 +647,7 @@ func TestEncryptDecryptState(t *testing.T) {
 		SecretKey:       []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
 		ProtocolVersion: ProtocolVersionMax,
 	}
+	config.Logger = testLogger(t)
 
 	m, err := Create(config)
 	if err != nil {
@@ -787,8 +788,8 @@ func TestIngestPacket_CRC(t *testing.T) {
 }
 
 func TestGossip_MismatchedKeys(t *testing.T) {
-	c1 := testConfig()
-	c2 := testConfig()
+	c1 := testConfig(t)
+	c2 := testConfig(t)
 
 	// Create two agents with different gossip keys
 	c1.SecretKey = []byte("4W6DGn2VQVqDEceOdmuRTQ==")

--- a/state_test.go
+++ b/state_test.go
@@ -12,6 +12,7 @@ func HostMemberlist(host string, t *testing.T, f func(*Config)) *Memberlist {
 	c := DefaultLANConfig()
 	c.Name = host
 	c.BindAddr = host
+	c.Logger = testLogger(t)
 	if f != nil {
 		f(c)
 	}
@@ -861,6 +862,7 @@ func TestMemberList_Ping(t *testing.T) {
 
 func TestMemberList_ResetNodes(t *testing.T) {
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 	a1 := alive{Node: "test1", Addr: []byte{127, 0, 0, 1}, Incarnation: 1}
 	m.aliveNode(&a1, nil, false)
 	a2 := alive{Node: "test2", Addr: []byte{127, 0, 0, 2}, Incarnation: 1}
@@ -1047,6 +1049,7 @@ func TestMemberList_invokeAckHandler_Channel_Nack(t *testing.T) {
 func TestMemberList_AliveNode_NewNode(t *testing.T) {
 	ch := make(chan NodeEvent, 1)
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 	m.config.Events = &ChannelEventDelegate{ch}
 
 	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 1}
@@ -1090,6 +1093,7 @@ func TestMemberList_AliveNode_NewNode(t *testing.T) {
 func TestMemberList_AliveNode_SuspectNode(t *testing.T) {
 	ch := make(chan NodeEvent, 1)
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 
 	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 1}
 	m.aliveNode(&a, nil, false)
@@ -1135,6 +1139,7 @@ func TestMemberList_AliveNode_SuspectNode(t *testing.T) {
 func TestMemberList_AliveNode_Idempotent(t *testing.T) {
 	ch := make(chan NodeEvent, 1)
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 
 	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 1}
 	m.aliveNode(&a, nil, false)
@@ -1174,6 +1179,7 @@ func TestMemberList_AliveNode_Idempotent(t *testing.T) {
 func TestMemberList_AliveNode_ChangeMeta(t *testing.T) {
 	ch := make(chan NodeEvent, 1)
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 
 	a := alive{
 		Node:        "test",
@@ -1218,6 +1224,7 @@ func TestMemberList_AliveNode_ChangeMeta(t *testing.T) {
 
 func TestMemberList_AliveNode_Refute(t *testing.T) {
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 	a := alive{Node: m.config.Name, Addr: []byte{127, 0, 0, 1}, Incarnation: 1}
 	m.aliveNode(&a, nil, true)
 
@@ -1255,6 +1262,7 @@ func TestMemberList_AliveNode_Refute(t *testing.T) {
 
 func TestMemberList_SuspectNode_NoNode(t *testing.T) {
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 	s := suspect{Node: "test", Incarnation: 1}
 	m.suspectNode(&s)
 	if len(m.nodes) != 0 {
@@ -1264,6 +1272,7 @@ func TestMemberList_SuspectNode_NoNode(t *testing.T) {
 
 func TestMemberList_SuspectNode(t *testing.T) {
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 	m.config.ProbeInterval = time.Millisecond
 	m.config.SuspicionMult = 1
 	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 1}
@@ -1321,6 +1330,7 @@ func TestMemberList_SuspectNode(t *testing.T) {
 
 func TestMemberList_SuspectNode_DoubleSuspect(t *testing.T) {
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 1}
 	m.aliveNode(&a, nil, false)
 
@@ -1358,6 +1368,7 @@ func TestMemberList_SuspectNode_DoubleSuspect(t *testing.T) {
 
 func TestMemberList_SuspectNode_OldSuspect(t *testing.T) {
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 10}
 	m.aliveNode(&a, nil, false)
 
@@ -1382,6 +1393,7 @@ func TestMemberList_SuspectNode_OldSuspect(t *testing.T) {
 
 func TestMemberList_SuspectNode_Refute(t *testing.T) {
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 	a := alive{Node: m.config.Name, Addr: []byte{127, 0, 0, 1}, Incarnation: 1}
 	m.aliveNode(&a, nil, true)
 
@@ -1419,6 +1431,7 @@ func TestMemberList_SuspectNode_Refute(t *testing.T) {
 
 func TestMemberList_DeadNode_NoNode(t *testing.T) {
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 	d := dead{Node: "test", Incarnation: 1}
 	m.deadNode(&d)
 	if len(m.nodes) != 0 {
@@ -1429,6 +1442,7 @@ func TestMemberList_DeadNode_NoNode(t *testing.T) {
 func TestMemberList_DeadNode(t *testing.T) {
 	ch := make(chan NodeEvent, 1)
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 	m.config.Events = &ChannelEventDelegate{ch}
 	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 1}
 	m.aliveNode(&a, nil, false)
@@ -1474,6 +1488,7 @@ func TestMemberList_DeadNode(t *testing.T) {
 func TestMemberList_DeadNode_Double(t *testing.T) {
 	ch := make(chan NodeEvent, 1)
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 1}
 	m.aliveNode(&a, nil, false)
 
@@ -1507,6 +1522,7 @@ func TestMemberList_DeadNode_Double(t *testing.T) {
 
 func TestMemberList_DeadNode_OldDead(t *testing.T) {
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 10}
 	m.aliveNode(&a, nil, false)
 
@@ -1523,6 +1539,7 @@ func TestMemberList_DeadNode_OldDead(t *testing.T) {
 
 func TestMemberList_DeadNode_AliveReplay(t *testing.T) {
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 10}
 	m.aliveNode(&a, nil, false)
 
@@ -1541,6 +1558,7 @@ func TestMemberList_DeadNode_AliveReplay(t *testing.T) {
 
 func TestMemberList_DeadNode_Refute(t *testing.T) {
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 	a := alive{Node: m.config.Name, Addr: []byte{127, 0, 0, 1}, Incarnation: 1}
 	m.aliveNode(&a, nil, true)
 
@@ -1578,6 +1596,7 @@ func TestMemberList_DeadNode_Refute(t *testing.T) {
 
 func TestMemberList_MergeState(t *testing.T) {
 	m := GetMemberlist(t)
+	defer m.Shutdown()
 	a1 := alive{Node: "test1", Addr: []byte{127, 0, 0, 1}, Incarnation: 1}
 	m.aliveNode(&a1, nil, false)
 	a2 := alive{Node: "test2", Addr: []byte{127, 0, 0, 2}, Incarnation: 1}

--- a/transport_test.go
+++ b/transport_test.go
@@ -15,6 +15,7 @@ func TestTransport_Join(t *testing.T) {
 	c1 := DefaultLANConfig()
 	c1.Name = "node1"
 	c1.Transport = t1
+	c1.Logger = testLogger(t)
 	m1, err := Create(c1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -26,6 +27,7 @@ func TestTransport_Join(t *testing.T) {
 	c2 := DefaultLANConfig()
 	c2.Name = "node2"
 	c2.Transport = net.NewTransport()
+	c2.Logger = testLogger(t)
 	m2, err := Create(c2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -61,6 +63,7 @@ func TestTransport_Send(t *testing.T) {
 	c1.Name = "node1"
 	c1.Transport = t1
 	c1.Delegate = d1
+	c1.Logger = testLogger(t)
 	m1, err := Create(c1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -72,6 +75,7 @@ func TestTransport_Send(t *testing.T) {
 	c2 := DefaultLANConfig()
 	c2.Name = "node2"
 	c2.Transport = net.NewTransport()
+	c2.Logger = testLogger(t)
 	m2, err := Create(c2)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/z_test.go
+++ b/z_test.go
@@ -1,0 +1,20 @@
+package memberlist
+
+import (
+	"log"
+	"testing"
+)
+
+func testLogger(t testing.TB) *log.Logger {
+	return log.New(testWriter{t}, "test: ", log.LstdFlags)
+}
+
+type testWriter struct {
+	t testing.TB
+}
+
+func (tw testWriter) Write(p []byte) (n int, err error) {
+	tw.t.Helper()
+	tw.t.Log(string(p))
+	return len(p), nil
+}


### PR DESCRIPTION
* Send logger output to testing.Logf.
* Use testing.TB instead of *testing.T in a few places to make it easier to setup benchmarks.
* Try to Shutdown memberlist where possible in tests.

Before this change:
```
$ go test 2>&1 | wc -l
239
```
After this change:
```
$ go test 2>&1 | wc -l
2
```