### PR TITLE
Unflake a bunch of tests.

### DIFF
--- a/integ_test.go
+++ b/integ_test.go
@@ -2,7 +2,6 @@ package memberlist
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"testing"
 	"time"
@@ -42,6 +41,7 @@ func TestMemberlist_Integ(t *testing.T) {
 		c.GossipInterval = 20 * time.Millisecond
 		c.PushPullInterval = 200 * time.Millisecond
 		c.SecretKey = secret
+		c.Logger = testLoggerWithName(t, c.Name)
 
 		if i == 0 {
 			c.Events = &ChannelEventDelegate{eventCh}
@@ -51,8 +51,9 @@ func TestMemberlist_Integ(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err: %s", err)
 		}
-		members = append(members, m)
 		defer m.Shutdown()
+
+		members = append(members, m)
 
 		if i > 0 {
 			last := members[i-1]
@@ -70,9 +71,9 @@ WAIT:
 		select {
 		case e := <-eventCh:
 			if e.Event == NodeJoin {
-				log.Printf("[DEBUG] Node join: %v (%d)", *e.Node, members[0].NumMembers())
+				t.Logf("[DEBUG] Node join: %v (%d)", *e.Node, members[0].NumMembers())
 			} else {
-				log.Printf("[DEBUG] Node leave: %v (%d)", *e.Node, members[0].NumMembers())
+				t.Logf("[DEBUG] Node leave: %v (%d)", *e.Node, members[0].NumMembers())
 			}
 		case <-breakTimer:
 			break WAIT

--- a/memberlist.go
+++ b/memberlist.go
@@ -665,3 +665,27 @@ func (m *Memberlist) hasShutdown() bool {
 func (m *Memberlist) hasLeft() bool {
 	return atomic.LoadInt32(&m.leave) == 1
 }
+
+func (m *Memberlist) getNodeState(addr string) nodeStateType {
+	m.nodeLock.RLock()
+	defer m.nodeLock.RUnlock()
+
+	n := m.nodeMap[addr]
+	return n.State
+}
+
+func (m *Memberlist) getNodeStateChange(addr string) time.Time {
+	m.nodeLock.RLock()
+	defer m.nodeLock.RUnlock()
+
+	n := m.nodeMap[addr]
+	return n.StateChange
+}
+
+func (m *Memberlist) changeNode(addr string, f func(*nodeState)) {
+	m.nodeLock.Lock()
+	defer m.nodeLock.Unlock()
+
+	n := m.nodeMap[addr]
+	f(n)
+}

--- a/queue.go
+++ b/queue.go
@@ -27,6 +27,26 @@ type limitedBroadcast struct {
 	transmits int // Number of transmissions attempted.
 	b         Broadcast
 }
+
+// for testing; emits in transmit order if reverse=false
+func (q *TransmitLimitedQueue) orderedView(reverse bool) []*limitedBroadcast {
+	q.Lock()
+	defer q.Unlock()
+
+	out := make([]*limitedBroadcast, 0, len(q.bcQueue))
+	if reverse {
+		for i := 0; i < len(q.bcQueue); i++ {
+			out = append(out, q.bcQueue[i])
+		}
+	} else {
+		for i := len(q.bcQueue) - 1; i >= 0; i-- {
+			out = append(out, q.bcQueue[i])
+		}
+	}
+
+	return out
+}
+
 type limitedBroadcasts []*limitedBroadcast
 
 // Broadcast is something that can be broadcasted via gossip to

--- a/state.go
+++ b/state.go
@@ -233,6 +233,15 @@ START:
 	m.probeNode(&node)
 }
 
+// probeNodeByAddr just safely calls probeNode given only the address of the node (for tests)
+func (m *Memberlist) probeNodeByAddr(addr string) {
+	m.nodeLock.RLock()
+	n := m.nodeMap[addr]
+	m.nodeLock.RUnlock()
+
+	m.probeNode(n)
+}
+
 // probeNode handles a single round of failure checking on a node.
 func (m *Memberlist) probeNode(node *nodeState) {
 	defer metrics.MeasureSince([]string{"memberlist", "probeNode"}, time.Now())

--- a/transport_test.go
+++ b/transport_test.go
@@ -123,8 +123,10 @@ func TestTransport_Send(t *testing.T) {
 
 	expected := []string{"SendTo", "SendToUDP", "SendToTCP", "SendBestEffort", "SendReliable"}
 
-	received := make([]string, len(d1.msgs))
-	for i, bs := range d1.msgs {
+	msgs1 := d1.getMessages()
+
+	received := make([]string, len(msgs1))
+	for i, bs := range msgs1 {
 		received[i] = string(bs)
 	}
 	// Some of these are UDP so often get re-ordered making the test flaky if we

--- a/z_test.go
+++ b/z_test.go
@@ -2,19 +2,24 @@ package memberlist
 
 import (
 	"log"
+	"strings"
 	"testing"
 )
 
 func testLogger(t testing.TB) *log.Logger {
-	return log.New(testWriter{t}, "test: ", log.LstdFlags)
+	return log.New(&testWriter{t}, "test: ", log.LstdFlags)
+}
+
+func testLoggerWithName(t testing.TB, name string) *log.Logger {
+	return log.New(&testWriter{t}, "test["+name+"]: ", log.LstdFlags)
 }
 
 type testWriter struct {
 	t testing.TB
 }
 
-func (tw testWriter) Write(p []byte) (n int, err error) {
+func (tw *testWriter) Write(p []byte) (n int, err error) {
 	tw.t.Helper()
-	tw.t.Log(string(p))
+	tw.t.Log(strings.TrimSpace(string(p)))
 	return len(p), nil
 }


### PR DESCRIPTION
* TestMemberlist_EncryptedGossipTransition was rewritten to actually test a recommended upgrade path, instead of testing a crazy split-brain situation that would fail the test roughly half of the time.
* Forced tests to defer a call to Memberlist.Shutdown to avoid bleedover.
* Forced each test to pick a random port for its cluster to avoid bleedover.
* Got tests to pass the race detector.