### PR TITLE
eliminate one of the data races on access to node data

### DIFF
--- a/util.go
+++ b/util.go
@@ -149,6 +149,16 @@ OUTER:
 		// Append the node
 		kNodes = append(kNodes, node)
 	}
+	kNodeStorage := make([]nodeState, len(kNodes))
+	// Copy the contents of the node pointers out to local storage, and
+	// return pointers to that, so we avoid races.
+	for i, node := range kNodes {
+		kNodeStorage[i] = *node
+		metaCopy := make([]byte, len(node.Meta))
+		copy(metaCopy, node.Meta)
+		kNodeStorage[i].Meta = metaCopy
+		kNodes[i] = &kNodeStorage[i]
+	}
 	return kNodes
 }
 


### PR DESCRIPTION
This particular data race hits us a lot in CI testing. The
underlying issue is that access to the contents of m.nodeMap
is controlled by a mutex, but rawSendMsgPacket is using the
mutex only to grab the pointer -- then accessing the contents
of the pointer without the mutex held. This means a data race
if something else grabs the mutex and modifies the contents
of the pointer as well.

In this particular case, access is read-only, so we copy the
pointed-to thing into a local. Less efficient, but also less
of a data race.

(Probably)
Fixes #113, #134 
(Well, not all of #134, but this was at least one of them.)