### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -29,7 +29,7 @@ func (b *memberlistBroadcast) Invalidates(other Broadcast) bool {
 	return b.node == mb.node
 }
 
-// memberlist.NamedBroadcast optional interface
+// Name: memberlist.NamedBroadcast optional interface
 func (b *memberlistBroadcast) Name() string {
 	return b.node
 }

--- a/config.go
+++ b/config.go
@@ -294,7 +294,7 @@ func DefaultLocalConfig() *Config {
 	return conf
 }
 
-// Returns whether or not encryption is enabled
+// EncryptionEnabled returns whether or not encryption is enabled
 func (c *Config) EncryptionEnabled() bool {
 	return c.Keyring != nil && len(c.Keyring.GetKeys()) > 0
 }

--- a/mock_transport.go
+++ b/mock_transport.go
@@ -39,12 +39,12 @@ type MockAddress struct {
 	addr string
 }
 
-// See net.Addr.
+// Network: See net.Addr.
 func (a *MockAddress) Network() string {
 	return "mock"
 }
 
-// See net.Addr.
+// String: See net.Addr.
 func (a *MockAddress) String() string {
 	return a.addr
 }
@@ -57,7 +57,7 @@ type MockTransport struct {
 	streamCh chan net.Conn
 }
 
-// See Transport.
+// FinalAdvertiseAddr: See Transport.
 func (t *MockTransport) FinalAdvertiseAddr(string, int) (net.IP, int, error) {
 	host, portStr, err := net.SplitHostPort(t.addr.String())
 	if err != nil {
@@ -77,7 +77,7 @@ func (t *MockTransport) FinalAdvertiseAddr(string, int) (net.IP, int, error) {
 	return ip, int(port), nil
 }
 
-// See Transport.
+// WriteTo: See Transport.
 func (t *MockTransport) WriteTo(b []byte, addr string) (time.Time, error) {
 	dest, ok := t.net.transports[addr]
 	if !ok {
@@ -93,12 +93,12 @@ func (t *MockTransport) WriteTo(b []byte, addr string) (time.Time, error) {
 	return now, nil
 }
 
-// See Transport.
+// PacketCh: See Transport.
 func (t *MockTransport) PacketCh() <-chan *Packet {
 	return t.packetCh
 }
 
-// See Transport.
+// DialTimeout: See Transport.
 func (t *MockTransport) DialTimeout(addr string, timeout time.Duration) (net.Conn, error) {
 	dest, ok := t.net.transports[addr]
 	if !ok {
@@ -110,12 +110,12 @@ func (t *MockTransport) DialTimeout(addr string, timeout time.Duration) (net.Con
 	return p2, nil
 }
 
-// See Transport.
+// StreamCh: See Transport.
 func (t *MockTransport) StreamCh() <-chan net.Conn {
 	return t.streamCh
 }
 
-// See Transport.
+// Shutdown: See Transport.
 func (t *MockTransport) Shutdown() error {
 	return nil
 }

--- a/net_transport.go
+++ b/net_transport.go
@@ -122,7 +122,7 @@ func (t *NetTransport) GetAutoBindPort() int {
 	return t.tcpListeners[0].Addr().(*net.TCPAddr).Port
 }
 
-// See Transport.
+// FinalAdvertiseAddr: See Transport.
 func (t *NetTransport) FinalAdvertiseAddr(ip string, port int) (net.IP, int, error) {
 	var advertiseAddr net.IP
 	var advertisePort int
@@ -168,7 +168,7 @@ func (t *NetTransport) FinalAdvertiseAddr(ip string, port int) (net.IP, int, err
 	return advertiseAddr, advertisePort, nil
 }
 
-// See Transport.
+// WriteTo: See Transport.
 func (t *NetTransport) WriteTo(b []byte, addr string) (time.Time, error) {
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
@@ -183,23 +183,23 @@ func (t *NetTransport) WriteTo(b []byte, addr string) (time.Time, error) {
 	return time.Now(), err
 }
 
-// See Transport.
+// PacketCh: See Transport.
 func (t *NetTransport) PacketCh() <-chan *Packet {
 	return t.packetCh
 }
 
-// See Transport.
+// DialTimeout: See Transport.
 func (t *NetTransport) DialTimeout(addr string, timeout time.Duration) (net.Conn, error) {
 	dialer := net.Dialer{Timeout: timeout}
 	return dialer.Dial("tcp", addr)
 }
 
-// See Transport.
+// StreamCh: See Transport.
 func (t *NetTransport) StreamCh() <-chan net.Conn {
 	return t.streamCh
 }
 
-// See Transport.
+// Shutdown: See Transport.
 func (t *NetTransport) Shutdown() error {
 	// This will avoid log spam about errors when we shut down.
 	atomic.StoreInt32(&t.shutdown, 1)


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, *but this is automated so feel free to close it and just say "opt out" to opt out of future CodeLingo outreach PRs.*