### PR TITLE
Allow a dead node's name to be taken by a new node

### DIFF
--- a/config.go
+++ b/config.go
@@ -215,6 +215,10 @@ type Config struct {
 	// This is a legacy name for backward compatibility but should really be
 	// called PacketBufferSize now that we have generalized the transport.
 	UDPBufferSize int
+
+	// AllowDeadNodeReclaim controls whether or not a dead node's name can be
+	// reclaimed by one with a different address or port.
+	AllowDeadNodeReclaim bool
 }
 
 // DefaultLANConfig returns a sane set of configurations for Memberlist.
@@ -258,6 +262,8 @@ func DefaultLANConfig() *Config {
 
 		HandoffQueueDepth: 1024,
 		UDPBufferSize:     1400,
+
+		AllowDeadNodeReclaim: false,
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -216,9 +216,10 @@ type Config struct {
 	// called PacketBufferSize now that we have generalized the transport.
 	UDPBufferSize int
 
-	// AllowDeadNodeReclaim controls whether or not a dead node's name can be
-	// reclaimed by one with a different address or port.
-	AllowDeadNodeReclaim bool
+	// DeadNodeReclaimTime controls the time before a dead node's name can be
+	// reclaimed by one with a different address or port. By default, this is 0,
+	// meaning nodes cannot be reclaimed this way.
+	DeadNodeReclaimTime time.Duration
 }
 
 // DefaultLANConfig returns a sane set of configurations for Memberlist.
@@ -262,8 +263,6 @@ func DefaultLANConfig() *Config {
 
 		HandoffQueueDepth: 1024,
 		UDPBufferSize:     1400,
-
-		AllowDeadNodeReclaim: false,
 	}
 }
 

--- a/state.go
+++ b/state.go
@@ -931,7 +931,7 @@ func (m *Memberlist) aliveNode(a *alive, notify chan struct{}, bootstrap bool) {
 		// Check if this address is different than the existing node unless the old node is dead.
 		if !bytes.Equal([]byte(state.Addr), a.Addr) || state.Port != a.Port {
 			// Allow the address to be updated if a dead node is being replaced.
-			if state.State == stateDead {
+			if state.State == stateDead && m.config.AllowDeadNodeReclaim {
 				m.logger.Printf("[INFO] memberlist: Updating address for failed node %s from %v:%d to %v:%d",
 					state.Name, state.Addr, state.Port, net.IP(a.Addr), a.Port)
 				updatesNode = true

--- a/state.go
+++ b/state.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/armon/go-metrics"
+	metrics "github.com/armon/go-metrics"
 )
 
 type nodeStateType int
@@ -891,6 +891,7 @@ func (m *Memberlist) aliveNode(a *alive, notify chan struct{}, bootstrap bool) {
 
 	// Check if we've never seen this node before, and if not, then
 	// store this node in our node map.
+	var updatesNode bool
 	if !ok {
 		state = &nodeState{
 			Node: Node{
@@ -926,29 +927,36 @@ func (m *Memberlist) aliveNode(a *alive, notify chan struct{}, bootstrap bool) {
 
 		// Update numNodes after we've added a new node
 		atomic.AddUint32(&m.numNodes, 1)
-	}
+	} else {
+		// Check if this address is different than the existing node unless the old node is dead.
+		if !bytes.Equal([]byte(state.Addr), a.Addr) || state.Port != a.Port {
+			// Allow the address to be updated if a dead node is being replaced.
+			if state.State == stateDead {
+				m.logger.Printf("[INFO] memberlist: Updating address for failed node %s from %v:%d to %v:%d",
+					state.Name, state.Addr, state.Port, net.IP(a.Addr), a.Port)
+				updatesNode = true
+			} else {
+				m.logger.Printf("[ERR] memberlist: Conflicting address for %s. Mine: %v:%d Theirs: %v:%d Old state: %v",
+					state.Name, state.Addr, state.Port, net.IP(a.Addr), a.Port, state.State)
 
-	// Check if this address is different than the existing node
-	if !bytes.Equal([]byte(state.Addr), a.Addr) || state.Port != a.Port {
-		m.logger.Printf("[ERR] memberlist: Conflicting address for %s. Mine: %v:%d Theirs: %v:%d",
-			state.Name, state.Addr, state.Port, net.IP(a.Addr), a.Port)
-
-		// Inform the conflict delegate if provided
-		if m.config.Conflict != nil {
-			other := Node{
-				Name: a.Node,
-				Addr: a.Addr,
-				Port: a.Port,
-				Meta: a.Meta,
+				// Inform the conflict delegate if provided
+				if m.config.Conflict != nil {
+					other := Node{
+						Name: a.Node,
+						Addr: a.Addr,
+						Port: a.Port,
+						Meta: a.Meta,
+					}
+					m.config.Conflict.NotifyConflict(&state.Node, &other)
+				}
+				return
 			}
-			m.config.Conflict.NotifyConflict(&state.Node, &other)
 		}
-		return
 	}
 
 	// Bail if the incarnation number is older, and this is not about us
 	isLocalNode := state.Name == m.config.Name
-	if a.Incarnation <= state.Incarnation && !isLocalNode {
+	if a.Incarnation <= state.Incarnation && !isLocalNode && !updatesNode {
 		return
 	}
 
@@ -1006,6 +1014,8 @@ func (m *Memberlist) aliveNode(a *alive, notify chan struct{}, bootstrap bool) {
 		// Update the state and incarnation number
 		state.Incarnation = a.Incarnation
 		state.Meta = a.Meta
+		state.Addr = a.Addr
+		state.Port = a.Port
 		if state.State != stateAlive {
 			state.State = stateAlive
 			state.StateChange = time.Now()

--- a/state.go
+++ b/state.go
@@ -931,10 +931,8 @@ func (m *Memberlist) aliveNode(a *alive, notify chan struct{}, bootstrap bool) {
 		// Check if this address is different than the existing node unless the old node is dead.
 		if !bytes.Equal([]byte(state.Addr), a.Addr) || state.Port != a.Port {
 			// If DeadNodeReclaimTime is configured, check if enough time has elapsed since the node died.
-			var canReclaim bool
-			if m.config.DeadNodeReclaimTime > 0 && state.StateChange.Add(m.config.DeadNodeReclaimTime).Before(time.Now()) {
-				canReclaim = true
-			}
+			canReclaim := (m.config.DeadNodeReclaimTime > 0 &&
+				time.Since(state.StateChange) > m.config.DeadNodeReclaimTime)
 
 			// Allow the address to be updated if a dead node is being replaced.
 			if state.State == stateDead && canReclaim {

--- a/state_test.go
+++ b/state_test.go
@@ -1474,7 +1474,7 @@ func TestMemberList_AliveNode_Refute(t *testing.T) {
 
 func TestMemberList_AliveNode_Conflict(t *testing.T) {
 	m := GetMemberlist(t, func(c *Config) {
-		c.AllowDeadNodeReclaim = true
+		c.DeadNodeReclaimTime = 10 * time.Millisecond
 	})
 	defer m.Shutdown()
 
@@ -1524,6 +1524,8 @@ func TestMemberList_AliveNode_Conflict(t *testing.T) {
 	if state.State != stateDead {
 		t.Fatalf("should be dead")
 	}
+
+	time.Sleep(m.config.DeadNodeReclaimTime)
 
 	// New alive node
 	s2 := alive{

--- a/state_test.go
+++ b/state_test.go
@@ -1473,7 +1473,9 @@ func TestMemberList_AliveNode_Refute(t *testing.T) {
 }
 
 func TestMemberList_AliveNode_Conflict(t *testing.T) {
-	m := GetMemberlist(t, nil)
+	m := GetMemberlist(t, func(c *Config) {
+		c.AllowDeadNodeReclaim = true
+	})
 	defer m.Shutdown()
 
 	nodeName := "test"


### PR DESCRIPTION
This change goes along with hashicorp/consul#5485 to allow a dead node's name to be reclaimed by a new node. There's more context in that PR but the summary is that a dead node could get stuck holding onto it's name when it was recreated with a new address.