### PR TITLE
Added way to block members using CIDR

### DIFF
--- a/config.go
+++ b/config.go
@@ -305,7 +305,7 @@ func DefaultLANConfig() *Config {
 
 		HandoffQueueDepth: 1024,
 		UDPBufferSize:     1400,
-		CidrsAllowed:      nil, // same as allow all
+		CIDRsAllowed:      nil, // same as allow all
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -327,7 +327,7 @@ func DefaultWANConfig() *Config {
 
 // IPMustBeChecked return true if IPAllowed must be called
 func (c *Config) IPMustBeChecked() bool {
-	return c.CIDRsAllowed != nil
+	return len(c.CIDRsAllowed) > 0
 }
 
 // IPAllowed return an error if access to memberlist is denied

--- a/config.go
+++ b/config.go
@@ -230,6 +230,9 @@ type Config struct {
 	// RequireNodeNames controls if the name of a node is required when sending
 	// a message to that node.
 	RequireNodeNames bool
+	// If nil, allow any connection (default), otherwise specify all networks
+	// allowed to connect (you must specify IPv6/IPv4 separately)
+	// Using [] will block all connections.
 	CidrsAllowed []net.IPNet
 }
 

--- a/config.go
+++ b/config.go
@@ -6,7 +6,10 @@ import (
 	"log"
 	"net"
 	"os"
+	"strings"
 	"time"
+
+	multierror "github.com/hashicorp/go-multierror"
 )
 
 type Config struct {
@@ -230,10 +233,10 @@ type Config struct {
 	// RequireNodeNames controls if the name of a node is required when sending
 	// a message to that node.
 	RequireNodeNames bool
-	// If nil, allow any connection (default), otherwise specify all networks
+	// CIDRsAllowed If nil, allow any connection (default), otherwise specify all networks
 	// allowed to connect (you must specify IPv6/IPv4 separately)
 	// Using [] will block all connections.
-	CidrsAllowed []net.IPNet
+	CIDRsAllowed []net.IPNet
 }
 
 // ParseCIDRs return a possible empty list of all Network that have been parsed
@@ -324,7 +327,7 @@ func DefaultWANConfig() *Config {
 
 // IPMustBeChecked return true if IPAllowed must be called
 func (c *Config) IPMustBeChecked() bool {
-	return c.CidrsAllowed != nil
+	return c.CIDRsAllowed != nil
 }
 
 // IPAllowed return an error if access to memberlist is denied
@@ -332,7 +335,7 @@ func (c *Config) IPAllowed(ip net.IP) error {
 	if !c.IPMustBeChecked() {
 		return nil
 	}
-	for _, n := range c.CidrsAllowed {
+	for _, n := range c.CIDRsAllowed {
 		if n.Contains(ip) {
 			return nil
 		}

--- a/config.go
+++ b/config.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	multierror "github.com/hashicorp/go-multierror"
 )
 
 type Config struct {
@@ -228,33 +230,40 @@ type Config struct {
 	// meaning nodes cannot be reclaimed this way.
 	DeadNodeReclaimTime time.Duration
 
-<<<<<<< HEAD
 	// RequireNodeNames controls if the name of a node is required when sending
 	// a message to that node.
 	RequireNodeNames bool
-=======
 	CidrsAllowed []net.IPNet
-	CidrsDenied  []net.IPNet
 }
 
 // ParseCIDRs return a possible empty list of all Network that have been parsed
 // In case of error, it returns succesfully parsed CIDRs and the last error found
 func ParseCIDRs(v []string) ([]net.IPNet, error) {
 	nets := make([]net.IPNet, 0)
-	var err error
 	if v == nil {
-		return nets, err
+		return nets, nil
 	}
+	var errs error
+	hasErrors := false
 	for _, p := range v {
 		_, net, err := net.ParseCIDR(strings.TrimSpace(p))
 		if err != nil {
 			err = fmt.Errorf("invalid cidr: %s", p)
+			errs = multierror.Append(errs, err)
+			hasErrors = true
 		} else {
 			nets = append(nets, *net)
 		}
 	}
+<<<<<<< HEAD
 	return nets, err
 >>>>>>> Added way to block members using CIDR
+=======
+	if !hasErrors {
+		errs = nil
+	}
+	return nets, errs
+>>>>>>> Applied suggestions from @rboyer
 }
 
 // DefaultLANConfig returns a sane set of configurations for Memberlist.
@@ -300,7 +309,7 @@ func DefaultLANConfig() *Config {
 		HandoffQueueDepth: 1024,
 		UDPBufferSize:     1400,
 		CidrsAllowed:      allowedCidrs,
-		CidrsDenied:       []net.IPNet{},
+		CidrsDenied:       nil,
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,101 @@
+package memberlist
+
+import (
+	"net"
+	"testing"
+)
+
+func Test_IsValidAddressDefaults(t *testing.T) {
+	tests := []string{
+		"127.0.0.1",
+		"127.0.0.5",
+		"10.0.0.9",
+		"172.16.0.7",
+		"192.168.2.1",
+		"fe80::aede:48ff:fe00:1122",
+		"::1",
+	}
+	config := DefaultLANConfig()
+	for _, ip := range tests {
+		localV4 := net.ParseIP(ip)
+		if err := config.IpAllowed(localV4); err != nil {
+			t.Fatalf("IP %s Localhost Should be accepted for LAN", ip)
+		}
+	}
+	config = DefaultWANConfig()
+	for _, ip := range tests {
+		localV4 := net.ParseIP(ip)
+		if err := config.IpAllowed(localV4); err != nil {
+			t.Fatalf("IP %s Localhost Should be accepted for WAN", ip)
+		}
+	}
+}
+
+func Test_IsValidAddressOverride(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		allow   []string
+		deny    []string
+		success []string
+		fail    []string
+	}{
+		{
+			name:    "Only IPv4",
+			allow:   []string{"0.0.0.0/0"},
+			deny:    []string{},
+			success: []string{"127.0.0.5", "10.0.0.9", "192.168.1.7"},
+			fail:    []string{"fe80::38bc:4dff:fe62:b1ae"},
+		},
+		{
+			name:    "Only IPv6",
+			allow:   []string{"::0/0"},
+			deny:    []string{},
+			success: []string{"fe80::38bc:4dff:fe62:b1ae"},
+			fail:    []string{"127.0.0.5", "10.0.0.9", "192.168.1.7"},
+		},
+		{
+			name:    "All OK but not localhost IPv4/6",
+			allow:   []string{"0.0.0.0/0", "::0/0"},
+			deny:    []string{"127.0.0.0/8", "::1/128"},
+			success: []string{"fe80::38bc:4dff:fe62:b1ae", "10.0.0.9", "192.168.1.7"},
+			fail:    []string{"::1", "127.0.0.5"},
+		},
+		{
+			name:    "Only 192.168.5.0 IPv4/6 without 192.168.5.1",
+			allow:   []string{"192.168.5.0/24", "::ffff:192.0.5.0/120"},
+			deny:    []string{"192.168.5.1/32", "::ffff:192.0.5.1/128"},
+			success: []string{"192.168.5.2", "::ffff:192.0.5.2", "192.168.5.3", "::ffff:192.0.5.3"},
+			fail:    []string{"8.8.8.8", "::1", "127.0.0.5", "192.168.5.1", "::ffff:192.0.5.1", "192.168.1.2", "::ffff:192.0.1.2"},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			config := DefaultLANConfig()
+			var err error
+			config.CidrsAllowed, err = ParseCIDRs(testCase.allow)
+			if err != nil {
+				t.Fatalf("failed parsing %s", testCase.allow)
+			}
+			config.CidrsDenied, err = ParseCIDRs(testCase.deny)
+			if err != nil {
+				t.Fatalf("failed parsing %s", testCase.deny)
+			}
+			for _, ips := range testCase.success {
+				ip := net.ParseIP(ips)
+				if err := config.IpAllowed(ip); err != nil {
+					t.Fatalf("Test case with %s should pass", ip)
+				}
+			}
+			for _, ips := range testCase.fail {
+				ip := net.ParseIP(ips)
+				if err := config.IpAllowed(ip); err == nil {
+					t.Fatalf("Test case with %s should fail", ip)
+				}
+			}
+		})
+
+	}
+
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,12 +1,8 @@
 package memberlist
 
 import (
-	"fmt"
 	"net"
-	"strings"
 	"testing"
-
-	multierror "github.com/hashicorp/go-multierror"
 )
 
 func Test_IsValidAddressDefaults(t *testing.T) {
@@ -33,32 +29,6 @@ func Test_IsValidAddressDefaults(t *testing.T) {
 			t.Fatalf("IP %s Localhost Should be accepted for WAN", ip)
 		}
 	}
-}
-
-// parseCIDRs return a possible empty list of all Network that have been parsed
-// In case of error, it returns successfully parsed CIDRs and the last error found
-// If nil is given it returns nil, nil
-func parseCIDRs(v []string) ([]net.IPNet, error) {
-	if v == nil {
-		return nil, nil
-	}
-	nets := make([]net.IPNet, 0)
-	var errs error
-	hasErrors := false
-	for _, p := range v {
-		_, net, err := net.ParseCIDR(strings.TrimSpace(p))
-		if err != nil {
-			err = fmt.Errorf("invalid cidr: %s", p)
-			errs = multierror.Append(errs, err)
-			hasErrors = true
-		} else {
-			nets = append(nets, *net)
-		}
-	}
-	if !hasErrors {
-		errs = nil
-	}
-	return nets, errs
 }
 
 func Test_IsValidAddressOverride(t *testing.T) {
@@ -105,7 +75,7 @@ func Test_IsValidAddressOverride(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			config := DefaultLANConfig()
 			var err error
-			config.CIDRsAllowed, err = parseCIDRs(testCase.allow)
+			config.CIDRsAllowed, err = ParseCIDRs(testCase.allow)
 			if err != nil {
 				t.Fatalf("failed parsing %s", testCase.allow)
 			}

--- a/config_test.go
+++ b/config_test.go
@@ -36,7 +36,7 @@ func Test_IsValidAddressDefaults(t *testing.T) {
 }
 
 // parseCIDRs return a possible empty list of all Network that have been parsed
-// In case of error, it returns succesfully parsed CIDRs and the last error found
+// In case of error, it returns successfully parsed CIDRs and the last error found
 // If nil is given it returns nil, nil
 func parseCIDRs(v []string) ([]net.IPNet, error) {
 	if v == nil {

--- a/config_test.go
+++ b/config_test.go
@@ -105,7 +105,7 @@ func Test_IsValidAddressOverride(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			config := DefaultLANConfig()
 			var err error
-			config.CidrsAllowed, err = parseCIDRs(testCase.allow)
+			config.CIDRsAllowed, err = parseCIDRs(testCase.allow)
 			if err != nil {
 				t.Fatalf("failed parsing %s", testCase.allow)
 			}

--- a/config_test.go
+++ b/config_test.go
@@ -46,12 +46,6 @@ func Test_IsValidAddressOverride(t *testing.T) {
 			fail:    []string{},
 		},
 		{
-			name:    "[] blocks all",
-			allow:   []string{},
-			success: []string{},
-			fail:    []string{"127.0.0.5", "10.0.0.9", "192.168.1.7", "::1"},
-		},
-		{
 			name:    "Only IPv4",
 			allow:   []string{"0.0.0.0/0"},
 			success: []string{"127.0.0.5", "10.0.0.9", "192.168.1.7"},

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -651,7 +651,7 @@ func TestMemberlist_Join(t *testing.T) {
 
 func TestMemberlist_JoinDifferentNetworksUniqueMask(t *testing.T) {
 	c1 := testConfigNet(t, 0)
-	c1.CidrsAllowed, _ = parseCIDRs([]string{"127.0.0.0/8"})
+	c1.CIDRsAllowed, _ = parseCIDRs([]string{"127.0.0.0/8"})
 	m1, err := Create(c1)
 	require.NoError(t, err)
 	defer m1.Shutdown()
@@ -660,7 +660,7 @@ func TestMemberlist_JoinDifferentNetworksUniqueMask(t *testing.T) {
 
 	// Create a second node
 	c2 := testConfigNet(t, 1)
-	c2.CidrsAllowed, _ = parseCIDRs([]string{"127.0.0.0/8"})
+	c2.CIDRsAllowed, _ = parseCIDRs([]string{"127.0.0.0/8"})
 	c2.BindPort = bindPort
 
 	m2, err := Create(c2)
@@ -686,7 +686,7 @@ func TestMemberlist_JoinDifferentNetworksUniqueMask(t *testing.T) {
 
 func TestMemberlist_JoinDifferentNetworksMultiMasks(t *testing.T) {
 	c1 := testConfigNet(t, 0)
-	c1.CidrsAllowed, _ = parseCIDRs([]string{"127.0.0.0/24", "127.0.1.0/24"})
+	c1.CIDRsAllowed, _ = parseCIDRs([]string{"127.0.0.0/24", "127.0.1.0/24"})
 	m1, err := Create(c1)
 	require.NoError(t, err)
 	defer m1.Shutdown()
@@ -695,7 +695,7 @@ func TestMemberlist_JoinDifferentNetworksMultiMasks(t *testing.T) {
 
 	// Create a second node
 	c2 := testConfigNet(t, 1)
-	c2.CidrsAllowed, _ = parseCIDRs([]string{"127.0.0.0/24", "127.0.1.0/24"})
+	c2.CIDRsAllowed, _ = parseCIDRs([]string{"127.0.0.0/24", "127.0.1.0/24"})
 	c2.BindPort = bindPort
 
 	m2, err := Create(c2)
@@ -710,7 +710,7 @@ func TestMemberlist_JoinDifferentNetworksMultiMasks(t *testing.T) {
 	// Create a rogue node that allows all networks
 	// It should see others, but will not be seen by others
 	c3 := testConfigNet(t, 2)
-	c3.CidrsAllowed, _ = parseCIDRs([]string{"127.0.0.0/8"})
+	c3.CIDRsAllowed, _ = parseCIDRs([]string{"127.0.0.0/8"})
 	c3.BindPort = bindPort
 
 	m3, err := Create(c3)
@@ -743,7 +743,7 @@ func TestMemberlist_JoinDifferentNetworksMultiMasks(t *testing.T) {
 	// Create a rogue node that allows all networks
 	// It should see others, but will not be seen by others
 	c4 := testConfigNet(t, 2)
-	c4.CidrsAllowed, _ = parseCIDRs([]string{"127.0.0.0/24", "127.0.1.0/24"})
+	c4.CIDRsAllowed, _ = parseCIDRs([]string{"127.0.0.0/24", "127.0.1.0/24"})
 	c4.BindPort = bindPort
 
 	m4, err := Create(c4)

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -667,7 +667,7 @@ func TestMemberlist_JoinDifferentNetworksUniqueMask(t *testing.T) {
 	require.NoError(t, err)
 	defer m2.Shutdown()
 
-	num, err := m2.Join([]string{m1.config.BindAddr})
+	num, err := m2.Join([]string{m1.config.Name + "/" + m1.config.BindAddr})
 	if num != 1 {
 		t.Fatalf("unexpected 1: %d", num)
 	}
@@ -702,7 +702,7 @@ func TestMemberlist_JoinDifferentNetworksMultiMasks(t *testing.T) {
 	require.NoError(t, err)
 	defer m2.Shutdown()
 
-	err = joinAndTestMemberShip(t, m2, []string{m1.config.BindAddr}, 2)
+	err = joinAndTestMemberShip(t, m2, []string{m1.config.Name + "/" + m1.config.BindAddr}, 2)
 	if err != nil {
 		t.Fatalf("unexpected err: %s", err)
 	}
@@ -718,7 +718,7 @@ func TestMemberlist_JoinDifferentNetworksMultiMasks(t *testing.T) {
 	defer m3.Shutdown()
 
 	// The rogue can see others, but others cannot see it
-	err = joinAndTestMemberShip(t, m3, []string{m1.config.BindAddr}, 3)
+	err = joinAndTestMemberShip(t, m3, []string{m1.config.Name + "/" + m1.config.BindAddr}, 3)
 	// For the node itself, everything seems fine, it should see others
 	if err != nil {
 		t.Fatalf("unexpected err: %s", err)
@@ -971,7 +971,7 @@ func TestMemberlist_Leave(t *testing.T) {
 	require.NoError(t, err)
 	defer m2.Shutdown()
 
-	err = joinAndTestMemberShip(t, m2, []string{m1.config.BindAddr}, 2)
+	err = joinAndTestMemberShip(t, m2, []string{m1.config.Name + "/" + m1.config.BindAddr}, 2)
 	if err != nil {
 		t.Fatalf("unexpected err: %s", err)
 	}

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -651,7 +651,7 @@ func TestMemberlist_Join(t *testing.T) {
 
 func TestMemberlist_JoinDifferentNetworksUniqueMask(t *testing.T) {
 	c1 := testConfigNet(t, 0)
-	c1.CIDRsAllowed, _ = parseCIDRs([]string{"127.0.0.0/8"})
+	c1.CIDRsAllowed, _ = ParseCIDRs([]string{"127.0.0.0/8"})
 	m1, err := Create(c1)
 	require.NoError(t, err)
 	defer m1.Shutdown()
@@ -660,7 +660,7 @@ func TestMemberlist_JoinDifferentNetworksUniqueMask(t *testing.T) {
 
 	// Create a second node
 	c2 := testConfigNet(t, 1)
-	c2.CIDRsAllowed, _ = parseCIDRs([]string{"127.0.0.0/8"})
+	c2.CIDRsAllowed, _ = ParseCIDRs([]string{"127.0.0.0/8"})
 	c2.BindPort = bindPort
 
 	m2, err := Create(c2)
@@ -686,7 +686,7 @@ func TestMemberlist_JoinDifferentNetworksUniqueMask(t *testing.T) {
 
 func TestMemberlist_JoinDifferentNetworksMultiMasks(t *testing.T) {
 	c1 := testConfigNet(t, 0)
-	c1.CIDRsAllowed, _ = parseCIDRs([]string{"127.0.0.0/24", "127.0.1.0/24"})
+	c1.CIDRsAllowed, _ = ParseCIDRs([]string{"127.0.0.0/24", "127.0.1.0/24"})
 	m1, err := Create(c1)
 	require.NoError(t, err)
 	defer m1.Shutdown()
@@ -695,7 +695,7 @@ func TestMemberlist_JoinDifferentNetworksMultiMasks(t *testing.T) {
 
 	// Create a second node
 	c2 := testConfigNet(t, 1)
-	c2.CIDRsAllowed, _ = parseCIDRs([]string{"127.0.0.0/24", "127.0.1.0/24"})
+	c2.CIDRsAllowed, _ = ParseCIDRs([]string{"127.0.0.0/24", "127.0.1.0/24"})
 	c2.BindPort = bindPort
 
 	m2, err := Create(c2)
@@ -710,7 +710,7 @@ func TestMemberlist_JoinDifferentNetworksMultiMasks(t *testing.T) {
 	// Create a rogue node that allows all networks
 	// It should see others, but will not be seen by others
 	c3 := testConfigNet(t, 2)
-	c3.CIDRsAllowed, _ = parseCIDRs([]string{"127.0.0.0/8"})
+	c3.CIDRsAllowed, _ = ParseCIDRs([]string{"127.0.0.0/8"})
 	c3.BindPort = bindPort
 
 	m3, err := Create(c3)
@@ -743,7 +743,7 @@ func TestMemberlist_JoinDifferentNetworksMultiMasks(t *testing.T) {
 	// Create a rogue node that allows all networks
 	// It should see others, but will not be seen by others
 	c4 := testConfigNet(t, 2)
-	c4.CIDRsAllowed, _ = parseCIDRs([]string{"127.0.0.0/24", "127.0.1.0/24"})
+	c4.CIDRsAllowed, _ = ParseCIDRs([]string{"127.0.0.0/24", "127.0.1.0/24"})
 	c4.BindPort = bindPort
 
 	m4, err := Create(c4)

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -21,11 +21,11 @@ import (
 var bindLock sync.Mutex
 var bindNum byte = 10
 
-func getBindAddr() net.IP {
+func getBindAddrNet(network byte) net.IP {
 	bindLock.Lock()
 	defer bindLock.Unlock()
 
-	result := net.IPv4(127, 0, 0, bindNum)
+	result := net.IPv4(127, 0, network, bindNum)
 	bindNum++
 	if bindNum > 255 {
 		bindNum = 10
@@ -34,11 +34,15 @@ func getBindAddr() net.IP {
 	return result
 }
 
-func testConfig(tb testing.TB) *Config {
+func getBindAddr() net.IP {
+	return getBindAddrNet(0)
+}
+
+func testConfigNet(tb testing.TB, network byte) *Config {
 	tb.Helper()
 
 	config := DefaultLANConfig()
-	config.BindAddr = getBindAddr().String()
+	config.BindAddr = getBindAddrNet(network).String()
 	config.Name = config.BindAddr
 	config.BindPort = 0 // choose free port
 	if tb != nil {
@@ -46,6 +50,10 @@ func testConfig(tb testing.TB) *Config {
 	}
 	config.RequireNodeNames = true
 	return config
+}
+
+func testConfig(tb testing.TB) *Config {
+	return testConfigNet(tb, 0)
 }
 
 func yield() {
@@ -641,6 +649,125 @@ func TestMemberlist_Join(t *testing.T) {
 	}
 }
 
+func TestMemberlist_JoinDifferentNetworksUniqueMask(t *testing.T) {
+	c1 := testConfigNet(t, 0)
+	c1.CidrsAllowed, _ = parseCIDRs([]string{"127.0.0.0/8"})
+	m1, err := Create(c1)
+	require.NoError(t, err)
+	defer m1.Shutdown()
+
+	bindPort := m1.config.BindPort
+
+	// Create a second node
+	c2 := testConfigNet(t, 1)
+	c2.CidrsAllowed, _ = parseCIDRs([]string{"127.0.0.0/8"})
+	c2.BindPort = bindPort
+
+	m2, err := Create(c2)
+	require.NoError(t, err)
+	defer m2.Shutdown()
+
+	num, err := m2.Join([]string{m1.config.BindAddr})
+	if num != 1 {
+		t.Fatalf("unexpected 1: %d", num)
+	}
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+
+	// Check the hosts
+	if len(m2.Members()) != 2 {
+		t.Fatalf("should have 2 nodes! %v", m2.Members())
+	}
+	if m2.estNumNodes() != 2 {
+		t.Fatalf("should have 2 nodes! %v", m2.Members())
+	}
+}
+
+func TestMemberlist_JoinDifferentNetworksMultiMasks(t *testing.T) {
+	c1 := testConfigNet(t, 0)
+	c1.CidrsAllowed, _ = parseCIDRs([]string{"127.0.0.0/24", "127.0.1.0/24"})
+	m1, err := Create(c1)
+	require.NoError(t, err)
+	defer m1.Shutdown()
+
+	bindPort := m1.config.BindPort
+
+	// Create a second node
+	c2 := testConfigNet(t, 1)
+	c2.CidrsAllowed, _ = parseCIDRs([]string{"127.0.0.0/24", "127.0.1.0/24"})
+	c2.BindPort = bindPort
+
+	m2, err := Create(c2)
+	require.NoError(t, err)
+	defer m2.Shutdown()
+
+	err = joinAndTestMemberShip(t, m2, []string{m1.config.BindAddr}, 2)
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+
+	// Create a rogue node that allows all networks
+	// It should see others, but will not be seen by others
+	c3 := testConfigNet(t, 2)
+	c3.CidrsAllowed, _ = parseCIDRs([]string{"127.0.0.0/8"})
+	c3.BindPort = bindPort
+
+	m3, err := Create(c3)
+	require.NoError(t, err)
+	defer m3.Shutdown()
+
+	// The rogue can see others, but others cannot see it
+	err = joinAndTestMemberShip(t, m3, []string{m1.config.BindAddr}, 3)
+	// For the node itself, everything seems fine, it should see others
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+
+	// m1 and m2 should not see newcomer however
+	if len(m1.Members()) != 2 {
+		t.Fatalf("m1 should have 2 nodes! %v", m1.Members())
+	}
+	if m1.estNumNodes() != 2 {
+		t.Fatalf("m1 should have 2 est. nodes! %v", m1.estNumNodes())
+	}
+
+	if len(m2.Members()) != 2 {
+		t.Fatalf("m2 should have 2 nodes! %v", m2.Members())
+	}
+	if m2.estNumNodes() != 2 {
+		t.Fatalf("m2 should have 2 est. nodes! %v", m2.estNumNodes())
+	}
+
+	// Another rogue, this time with a config that denies itself
+	// Create a rogue node that allows all networks
+	// It should see others, but will not be seen by others
+	c4 := testConfigNet(t, 2)
+	c4.CidrsAllowed, _ = parseCIDRs([]string{"127.0.0.0/24", "127.0.1.0/24"})
+	c4.BindPort = bindPort
+
+	m4, err := Create(c4)
+	require.NoError(t, err)
+	defer m4.Shutdown()
+
+	// This time, the node should not even see itself, so 2 expected nodes
+	err = joinAndTestMemberShip(t, m4, []string{m1.config.BindAddr, m2.config.BindAddr}, 2)
+	// m1 and m2 should not see newcomer however
+	if len(m1.Members()) != 2 {
+		t.Fatalf("m1 should have 2 nodes! %v", m1.Members())
+	}
+	if m1.estNumNodes() != 2 {
+		t.Fatalf("m1 should have 2 est. nodes! %v", m1.estNumNodes())
+	}
+
+	if len(m2.Members()) != 2 {
+		t.Fatalf("m2 should have 2 nodes! %v", m2.Members())
+	}
+	if m2.estNumNodes() != 2 {
+		t.Fatalf("m2 should have 2 est. nodes! %v", m2.estNumNodes())
+	}
+}
+
 type CustomMergeDelegate struct {
 	invoked bool
 	t       *testing.T
@@ -799,6 +926,28 @@ func TestMemberlist_Join_protocolVersions(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func joinAndTestMemberShip(t *testing.T, self *Memberlist, membersToJoin []string, expectedMembers int) error {
+	t.Helper()
+	num, err := self.Join(membersToJoin)
+	if err != nil {
+		return err
+	}
+	if num != len(membersToJoin) {
+		t.Fatalf("unexpected %d, was expecting %d to be joined", num, len(membersToJoin))
+	}
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+	// Check the hosts
+	if len(self.Members()) != expectedMembers {
+		t.Fatalf("should have 2 nodes! %v", self.Members())
+	}
+	if len(self.Members()) != expectedMembers {
+		t.Fatalf("should have 2 nodes! %v", self.Members())
+	}
+	return nil
+}
+
 func TestMemberlist_Leave(t *testing.T) {
 	newConfig := func() *Config {
 		c := testConfig(t)
@@ -822,20 +971,9 @@ func TestMemberlist_Leave(t *testing.T) {
 	require.NoError(t, err)
 	defer m2.Shutdown()
 
-	num, err := m2.Join([]string{m1.config.Name + "/" + m1.config.BindAddr})
-	if num != 1 {
-		t.Fatalf("unexpected 1: %d", num)
-	}
+	err = joinAndTestMemberShip(t, m2, []string{m1.config.BindAddr}, 2)
 	if err != nil {
 		t.Fatalf("unexpected err: %s", err)
-	}
-
-	// Check the hosts
-	if len(m2.Members()) != 2 {
-		t.Fatalf("should have 2 nodes! %v", m2.Members())
-	}
-	if len(m1.Members()) != 2 {
-		t.Fatalf("should have 2 nodes! %v", m2.Members())
 	}
 
 	// Leave

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -49,7 +49,7 @@ func testConfig(tb testing.TB) *Config {
 }
 
 func yield() {
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 }
 
 type MockDelegate struct {
@@ -1475,7 +1475,7 @@ func TestMemberlist_conflictDelegate(t *testing.T) {
 
 	// Ensure we were notified
 	if mock.existing == nil || mock.other == nil {
-		t.Fatalf("should get notified")
+		t.Fatalf("should get notified mock.existing=%v  VS mock.other=%v", mock.existing, mock.other)
 	}
 	if mock.existing.Name != mock.other.Name {
 		t.Fatalf("bad: %v %v", mock.existing, mock.other)
@@ -1571,7 +1571,7 @@ func TestMemberlist_PingDelegate(t *testing.T) {
 
 func waitUntilSize(t *testing.T, m *Memberlist, expected int) {
 	t.Helper()
-	retry(t, 15, 250*time.Millisecond, func(failf func(string, ...interface{})) {
+	retry(t, 15, 500*time.Millisecond, func(failf func(string, ...interface{})) {
 		t.Helper()
 
 		if m.NumMembers() != expected {

--- a/net.go
+++ b/net.go
@@ -622,9 +622,12 @@ func (m *Memberlist) handleSuspect(buf []byte, from net.Addr) {
 	m.suspectNode(&sus)
 }
 
-// EnsureCanConnect return the IP from a RemoteAddress
+// ensureCanConnect return the IP from a RemoteAddress
 // return error if this client must not connect
-func (m *Memberlist) EnsureCanConnect(from net.Addr) error {
+func (m *Memberlist) ensureCanConnect(from net.Addr) error {
+	if !m.config.IPMustBeChecked() {
+		return nil
+	}
 	source := from.String()
 	if source == "pipe" {
 		return nil
@@ -638,7 +641,7 @@ func (m *Memberlist) EnsureCanConnect(from net.Addr) error {
 	if ip == nil {
 		return fmt.Errorf("Cannot parse IP from %s", host)
 	}
-	return m.config.IpAllowed(ip)
+	return m.config.IPAllowed(ip)
 }
 
 func (m *Memberlist) handleAlive(buf []byte, from net.Addr) {
@@ -654,7 +657,7 @@ func (m *Memberlist) handleAlive(buf []byte, from net.Addr) {
 		live.Port = uint16(m.config.BindPort)
 	}
 
-	if err := m.EnsureCanConnect(from); err != nil {
+	if err := m.ensureCanConnect(from); err != nil {
 		m.logger.Printf("[DEBUG] memberlist: Blocked alive message: %s %s", err, LogAddress(from))
 		return
 	}

--- a/net.go
+++ b/net.go
@@ -654,11 +654,13 @@ func (m *Memberlist) handleAlive(buf []byte, from net.Addr) {
 		m.logger.Printf("[ERR] memberlist: Failed to decode alive message: %s %s", err, LogAddress(from))
 		return
 	}
-	innerIP := net.IP(live.Addr)
-	if innerIP != nil {
-		if err := m.config.IPAllowed(innerIP); err != nil {
-			m.logger.Printf("[DEBUG] memberlist: Blocked alive.Addr=%s message from: %s %s", innerIP.String(), err, LogAddress(from))
-			return
+	if m.config.IPMustBeChecked() {
+		innerIP := net.IP(live.Addr)
+		if innerIP != nil {
+			if err := m.config.IPAllowed(innerIP); err != nil {
+				m.logger.Printf("[DEBUG] memberlist: Blocked alive.Addr=%s message from: %s %s", innerIP.String(), err, LogAddress(from))
+				return
+			}
 		}
 	}
 

--- a/net.go
+++ b/net.go
@@ -218,9 +218,9 @@ func (m *Memberlist) streamListen() {
 	}
 }
 
-// EnsureCanConnect return the IP from a RemoteAddress
+// EnsureIsAllowed return the IP from a RemoteAddress
 // return error if this client must not connect
-func (m *Memberlist) EnsureCanConnect(from net.Addr) error {
+func (m *Memberlist) EnsureIsAllowed(from net.Addr) error {
 	source := from.String()
 	if source == "pipe" {
 		return nil
@@ -240,7 +240,7 @@ func (m *Memberlist) EnsureCanConnect(from net.Addr) error {
 // handleConn handles a single incoming stream connection from the transport.
 func (m *Memberlist) handleConn(conn net.Conn) {
 	defer conn.Close()
-	errCon := m.EnsureCanConnect(conn.RemoteAddr())
+	errCon := m.EnsureIsAllowed(conn.RemoteAddr())
 	if errCon != nil {
 		m.logger.Printf("[WARN] memberlist: Rejected connection %s (%s)", LogConn(conn), errCon)
 		return
@@ -346,7 +346,7 @@ func (m *Memberlist) packetListen() {
 }
 
 func (m *Memberlist) ingestPacket(buf []byte, from net.Addr, timestamp time.Time) {
-	if err := m.EnsureCanConnect(from); err != nil {
+	if err := m.EnsureIsAllowed(from); err != nil {
 		m.logger.Printf("[ERR] memberlist: Rejected packet: %v %s", err, LogAddress(from))
 	}
 	// Check if encryption is enabled

--- a/net.go
+++ b/net.go
@@ -654,6 +654,13 @@ func (m *Memberlist) handleAlive(buf []byte, from net.Addr) {
 		m.logger.Printf("[ERR] memberlist: Failed to decode alive message: %s %s", err, LogAddress(from))
 		return
 	}
+	innerIP := net.IP(live.Addr)
+	if innerIP != nil {
+		if err := m.config.IPAllowed(innerIP); err != nil {
+			m.logger.Printf("[DEBUG] memberlist: Blocked alive.Addr=%s message from: %s %s", innerIP.String(), err, LogAddress(from))
+			return
+		}
+	}
 
 	// For proto versions < 2, there is no port provided. Mask old
 	// behavior by using the configured port

--- a/state.go
+++ b/state.go
@@ -969,6 +969,11 @@ func (m *Memberlist) aliveNode(a *alive, notify chan struct{}, bootstrap bool) {
 	// store this node in our node map.
 	var updatesNode bool
 	if !ok {
+		errCon := m.config.IpAllowed(a.Addr)
+		if errCon != nil {
+			m.logger.Printf("[WARN] memberlist: Rejected node %s (%v): %s", a.Node, net.IP(a.Addr), errCon)
+			return
+		}
 		state = &nodeState{
 			Node: Node{
 				Name: a.Node,
@@ -1006,6 +1011,11 @@ func (m *Memberlist) aliveNode(a *alive, notify chan struct{}, bootstrap bool) {
 	} else {
 		// Check if this address is different than the existing node unless the old node is dead.
 		if !bytes.Equal([]byte(state.Addr), a.Addr) || state.Port != a.Port {
+			errCon := m.config.IpAllowed(a.Addr)
+			if errCon != nil {
+				m.logger.Printf("[WARN] memberlist: Rejected IP update from %v to %v for node %s: %s", a.Node, state.Addr, net.IP(a.Addr), errCon)
+				return
+			}
 			// If DeadNodeReclaimTime is configured, check if enough time has elapsed since the node died.
 			canReclaim := (m.config.DeadNodeReclaimTime > 0 &&
 				time.Since(state.StateChange) > m.config.DeadNodeReclaimTime)

--- a/state.go
+++ b/state.go
@@ -969,7 +969,7 @@ func (m *Memberlist) aliveNode(a *alive, notify chan struct{}, bootstrap bool) {
 	// store this node in our node map.
 	var updatesNode bool
 	if !ok {
-		errCon := m.config.IpAllowed(a.Addr)
+		errCon := m.config.IPAllowed(a.Addr)
 		if errCon != nil {
 			m.logger.Printf("[WARN] memberlist: Rejected node %s (%v): %s", a.Node, net.IP(a.Addr), errCon)
 			return
@@ -1011,7 +1011,7 @@ func (m *Memberlist) aliveNode(a *alive, notify chan struct{}, bootstrap bool) {
 	} else {
 		// Check if this address is different than the existing node unless the old node is dead.
 		if !bytes.Equal([]byte(state.Addr), a.Addr) || state.Port != a.Port {
-			errCon := m.config.IpAllowed(a.Addr)
+			errCon := m.config.IPAllowed(a.Addr)
 			if errCon != nil {
 				m.logger.Printf("[WARN] memberlist: Rejected IP update from %v to %v for node %s: %s", a.Node, state.Addr, net.IP(a.Addr), errCon)
 				return

--- a/test/setup_subnet.sh
+++ b/test/setup_subnet.sh
@@ -4,11 +4,16 @@
 # is a bug that it isn't routable and this causes errors.
 #
 
-# Check if loopback is setup
-ping -c 1 -W 10 127.0.0.2 > /dev/null 2>&1
-if [ $? -eq 0 ]
+action=${1:-up}
+
+if [  "$action" = "up" ]
 then
-    exit
+  # Check if loopback is setup
+  ping -c 1 -W 10 127.0.0.2 > /dev/null 2>&1
+  if [ $? -eq 0 ]
+  then
+      exit
+  fi
 fi
 
 # If we're not on OS X, then error
@@ -22,7 +27,15 @@ case $OSTYPE in
 esac
 
 # Setup loopback
-for ((i=2;i<256;i++))
+for j in 0 1 2
 do
-    sudo ifconfig lo0 alias 127.0.0.$i up
+  for ((i=2;i<256;i++))
+  do
+      if [ "$action" = "up" ]
+      then
+        sudo ifconfig lo0 alias 127.0.$j.$i up
+      else
+        sudo ifconfig lo0 127.0.$j.$i delete
+     fi
+  done
 done


### PR DESCRIPTION
Added 2 new fields in configuration of memberlists to allow/disallow
others machines joining memberlist.

This will allow protecting some machines from joining a cluster and will increase security as well.

Will be useful to implement https://github.com/hashicorp/consul/pull/5916
as suggested my @mkeller