### PR TITLE
Don't advertise a '::' bindAddr

### DIFF
--- a/net_transport.go
+++ b/net_transport.go
@@ -139,7 +139,8 @@ func (t *NetTransport) FinalAdvertiseAddr(ip string, port int) (net.IP, int, err
 		}
 		advertisePort = port
 	} else {
-		if t.config.BindAddrs[0] == "0.0.0.0" {
+		bindAddr := net.ParseIP(t.config.BindAddrs[0])
+		if bindAddr == nil || bindAddr.IsUnspecified() {
 			// Otherwise, if we're not bound to a specific IP, let's
 			// use a suitable private IP address.
 			var err error


### PR DESCRIPTION
If no no explicit advertiseAddr is specified and we're bound
to a wildcard address, we don't want to advertise the wildcard
address if it's '::'.

Instead of checking for 0.0.0.0 use the Go stdlib to select
for all possible wild card addresses