### PR TITLE
handle TCP transports properly

### DIFF
--- a/mock_transport.go
+++ b/mock_transport.go
@@ -119,3 +119,7 @@ func (t *MockTransport) StreamCh() <-chan net.Conn {
 func (t *MockTransport) Shutdown() error {
 	return nil
 }
+
+func (t *MockTransport) ProtocolType() ProtocolType {
+	return ProtocolTypeUDP
+}

--- a/net_transport.go
+++ b/net_transport.go
@@ -296,6 +296,10 @@ func (t *NetTransport) udpListen(udpLn *net.UDPConn) {
 	}
 }
 
+func (t *NetTransport) ProtocolType() ProtocolType {
+	return ProtocolTypeUDP
+}
+
 // setUDPRecvBuf is used to resize the UDP receive window. The function
 // attempts to set the read buffer to `udpRecvBuf` but backs off until
 // the read buffer can be set.

--- a/transport.go
+++ b/transport.go
@@ -21,6 +21,13 @@ type Packet struct {
 	Timestamp time.Time
 }
 
+type ProtocolType int
+
+const (
+	ProtocolTypeTCP ProtocolType = iota
+	ProtocolTypeUDP
+)
+
 // Transport is used to abstract over communicating with other peers. The packet
 // interface is assumed to be best-effort and the stream interface is assumed to
 // be reliable.
@@ -62,4 +69,6 @@ type Transport interface {
 	// Shutdown is called when memberlist is shutting down; this gives the
 	// transport a chance to clean up any listeners.
 	Shutdown() error
+
+	ProtocolType() ProtocolType
 }


### PR DESCRIPTION
If there would be a way to detect if a transport is TCP or UDP I would prefer that over implementing `ProtocolType()`.

The underlying issue is that UDP and TCP are different. And since any transport is allowed, memberlist must account for both cases. For example with TCP a ping fails while sending, while with UDP there is no response.