### PR TITLE
stateLeft

### DIFF
--- a/memberlist.go
+++ b/memberlist.go
@@ -579,6 +579,10 @@ func (m *Memberlist) Leave(timeout time.Duration) error {
 			return nil
 		}
 
+		// This dead message is special, because Node and From are the
+		// same. This helps other nodes figure out that a node left
+		// intentionally. When Node equals From, other nodes know for
+		// sure this node is gone.
 		d := dead{
 			Incarnation: state.Incarnation,
 			Node:        state.Name,

--- a/memberlist.go
+++ b/memberlist.go
@@ -525,7 +525,7 @@ func (m *Memberlist) Members() []*Node {
 
 	nodes := make([]*Node, 0, len(m.nodes))
 	for _, n := range m.nodes {
-		if n.State != stateDead {
+		if !n.DeadOrLeft() {
 			nodes = append(nodes, &n.Node)
 		}
 	}
@@ -542,7 +542,7 @@ func (m *Memberlist) NumMembers() (alive int) {
 	defer m.nodeLock.RUnlock()
 
 	for _, n := range m.nodes {
-		if n.State != stateDead {
+		if !n.DeadOrLeft() {
 			alive++
 		}
 	}
@@ -582,6 +582,7 @@ func (m *Memberlist) Leave(timeout time.Duration) error {
 		d := dead{
 			Incarnation: state.Incarnation,
 			Node:        state.Name,
+			From:        state.Name,
 		}
 		m.deadNode(&d)
 
@@ -607,7 +608,7 @@ func (m *Memberlist) anyAlive() bool {
 	m.nodeLock.RLock()
 	defer m.nodeLock.RUnlock()
 	for _, n := range m.nodes {
-		if n.State != stateDead && n.Name != m.config.Name {
+		if !n.DeadOrLeft() && n.Name != m.config.Name {
 			return true
 		}
 	}

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -747,6 +747,10 @@ func TestMemberlist_Leave(t *testing.T) {
 	if len(m2.Members()) != 1 {
 		t.Fatalf("should have 1 node")
 	}
+
+	if m2.nodeMap[c1.Name].State != stateLeft {
+		t.Fatalf("bad state")
+	}
 }
 
 func TestMemberlist_JoinShutdown(t *testing.T) {

--- a/state.go
+++ b/state.go
@@ -969,7 +969,7 @@ func (m *Memberlist) aliveNode(a *alive, notify chan struct{}, bootstrap bool) {
 
 			// Allow the address to be updated if a dead node is being replaced.
 			if state.State == stateLeft || (state.State == stateDead && canReclaim) {
-				m.logger.Printf("[INFO] memberlist: Updating address for failed node %s from %v:%d to %v:%d",
+				m.logger.Printf("[INFO] memberlist: Updating address for left or failed node %s from %v:%d to %v:%d",
 					state.Name, state.Addr, state.Port, net.IP(a.Addr), a.Port)
 				updatesNode = true
 			} else {

--- a/state.go
+++ b/state.go
@@ -19,6 +19,7 @@ const (
 	stateAlive nodeStateType = iota
 	stateSuspect
 	stateDead
+	stateLeft
 )
 
 // Node represents a node in the cluster.
@@ -58,6 +59,10 @@ type nodeState struct {
 // with a transport.
 func (n *nodeState) Address() string {
 	return n.Node.Address()
+}
+
+func (n *nodeState) DeadOrLeft() bool {
+	return n.State == stateDead || n.State == stateLeft
 }
 
 // ackHandler is used to register handlers for incoming acks and nacks.
@@ -218,7 +223,7 @@ START:
 	node = *m.nodes[m.probeIndex]
 	if node.Name == m.config.Name {
 		skip = true
-	} else if node.State == stateDead {
+	} else if node.DeadOrLeft() {
 		skip = true
 	}
 
@@ -963,7 +968,7 @@ func (m *Memberlist) aliveNode(a *alive, notify chan struct{}, bootstrap bool) {
 				time.Since(state.StateChange) > m.config.DeadNodeReclaimTime)
 
 			// Allow the address to be updated if a dead node is being replaced.
-			if state.State == stateDead && canReclaim {
+			if state.State == stateLeft || (state.State == stateDead && canReclaim) {
 				m.logger.Printf("[INFO] memberlist: Updating address for failed node %s from %v:%d to %v:%d",
 					state.Name, state.Addr, state.Port, net.IP(a.Addr), a.Port)
 				updatesNode = true
@@ -1059,8 +1064,8 @@ func (m *Memberlist) aliveNode(a *alive, notify chan struct{}, bootstrap bool) {
 
 	// Notify the delegate of any relevant updates
 	if m.config.Events != nil {
-		if oldState == stateDead {
-			// if Dead -> Alive, notify of join
+		if oldState == stateDead || oldState == stateLeft {
+			// if Dead/Left -> Alive, notify of join
 			m.config.Events.NotifyJoin(&state.Node)
 
 		} else if !bytes.Equal(oldMeta, state.Meta) {
@@ -1179,7 +1184,7 @@ func (m *Memberlist) deadNode(d *dead) {
 	delete(m.nodeTimers, d.Node)
 
 	// Ignore if node is already dead
-	if state.State == stateDead {
+	if state.DeadOrLeft() {
 		return
 	}
 
@@ -1203,7 +1208,14 @@ func (m *Memberlist) deadNode(d *dead) {
 
 	// Update the state
 	state.Incarnation = d.Incarnation
-	state.State = stateDead
+
+	// If the dead message was send by the node itself, mark it is left
+	// instead of dead.
+	if d.Node == d.From {
+		state.State = stateLeft
+	} else {
+		state.State = stateDead
+	}
 	state.StateChange = time.Now()
 
 	// Notify of death
@@ -1228,6 +1240,9 @@ func (m *Memberlist) mergeState(remote []pushNodeState) {
 			}
 			m.aliveNode(&a, nil, false)
 
+		case stateLeft:
+			d := dead{Incarnation: r.Incarnation, Node: r.Name, From: r.Name}
+			m.deadNode(&d)
 		case stateDead:
 			// If the remote node believes a node is dead, we prefer to
 			// suspect that node instead of declaring it dead instantly

--- a/state_test.go
+++ b/state_test.go
@@ -1763,29 +1763,15 @@ func TestMemberList_DeadNodeLeft(t *testing.T) {
 		t.Fatalf("Bad state")
 	}
 
-	// change := state.StateChange
-	// if time.Now().Sub(change) > time.Second {
-	// 	t.Fatalf("bad change delta")
-	// }
+	// Check a broad cast is queued
+	if m.broadcasts.NumQueued() != 1 {
+		t.Fatalf("expected only one queued message")
+	}
 
-	// select {
-	// case leave := <-ch:
-	// 	if leave.Event != NodeLeave || leave.Node.Name != "test" {
-	// 		t.Fatalf("bad node name")
-	// 	}
-	// default:
-	// 	t.Fatalf("no leave message")
-	// }
-
-	// // Check a broad cast is queued
-	// if m.broadcasts.NumQueued() != 1 {
-	// 	t.Fatalf("expected only one queued message")
-	// }
-
-	// // Check its a suspect message
-	// if messageType(m.broadcasts.orderedView(true)[0].b.Message()[0]) != deadMsg {
-	// 	t.Fatalf("expected queued dead msg")
-	// }
+	// Check its a suspect message
+	if messageType(m.broadcasts.orderedView(true)[0].b.Message()[0]) != deadMsg {
+		t.Fatalf("expected queued dead msg")
+	}
 }
 
 func TestMemberList_DeadNode(t *testing.T) {

--- a/state_test.go
+++ b/state_test.go
@@ -1741,6 +1741,53 @@ func TestMemberList_DeadNode_NoNode(t *testing.T) {
 	}
 }
 
+func TestMemberList_DeadNodeLeft(t *testing.T) {
+	ch := make(chan NodeEvent, 1)
+
+	m := GetMemberlist(t, func(c *Config) {
+		c.Events = &ChannelEventDelegate{ch}
+	})
+	defer m.Shutdown()
+
+	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	m.aliveNode(&a, nil, false)
+
+	// Read the join event
+	<-ch
+
+	d := dead{Node: "test", From: "test", Incarnation: 1}
+	m.deadNode(&d)
+
+	state := m.nodeMap["test"]
+	if state.State != stateLeft {
+		t.Fatalf("Bad state")
+	}
+
+	// change := state.StateChange
+	// if time.Now().Sub(change) > time.Second {
+	// 	t.Fatalf("bad change delta")
+	// }
+
+	// select {
+	// case leave := <-ch:
+	// 	if leave.Event != NodeLeave || leave.Node.Name != "test" {
+	// 		t.Fatalf("bad node name")
+	// 	}
+	// default:
+	// 	t.Fatalf("no leave message")
+	// }
+
+	// // Check a broad cast is queued
+	// if m.broadcasts.NumQueued() != 1 {
+	// 	t.Fatalf("expected only one queued message")
+	// }
+
+	// // Check its a suspect message
+	// if messageType(m.broadcasts.orderedView(true)[0].b.Message()[0]) != deadMsg {
+	// 	t.Fatalf("expected queued dead msg")
+	// }
+}
+
 func TestMemberList_DeadNode(t *testing.T) {
 	ch := make(chan NodeEvent, 1)
 


### PR DESCRIPTION
This PR introduces another state: `stateLeft`. This is an attempt to help fix https://github.com/hashicorp/consul/issues/6897.

When memberlist processes a `dead` message, it will now check where it is coming from and if the reporting node is equal to the reported node, we know this node wants to leave. In this case we don't have to prevent new nodes from using the same ip.

If a node reports another node, the behavior stays the same.

~~**Note:** this PR adds a new state which makes this update backwards incompatible because consumer of this library need to change their code to handle `stateLeft`. While I think a new state is the most elegant way to solve this problem, we could also add a flag to `nodeState` and not change the states.~~