### PR TITLE
Add public key encryption

### DIFF
--- a/config.go
+++ b/config.go
@@ -169,6 +169,11 @@ type Config struct {
 	// AES-192, or AES-256.
 	SecretKey []byte
 
+	// A unique key per cluster that is used enhance encryption keys to provide
+	// basic authentication. When this is set, the PKI version of the protocol
+	// is enabled.
+	AccessKey []byte
+
 	// The keyring holds all of the encryption keys used internally. It is
 	// automatically initialized using the SecretKey and SecretKeys values.
 	Keyring *Keyring
@@ -309,5 +314,5 @@ func DefaultLocalConfig() *Config {
 
 // Returns whether or not encryption is enabled
 func (c *Config) EncryptionEnabled() bool {
-	return c.Keyring != nil && len(c.Keyring.GetKeys()) > 0
+	return (c.Keyring != nil && len(c.Keyring.GetKeys()) > 0) || c.ProtocolVersion == ProtocolPKIVersion1
 }

--- a/config.go
+++ b/config.go
@@ -174,6 +174,12 @@ type Config struct {
 	// is enabled.
 	AccessKey []byte
 
+	// Private key to use for public key encryption along with the AccessKey.
+	// If one is not specified, an ephemeral key will be used. This is exposed
+	// to allow higher layers to generate and note keys to allow them to reject
+	// unknown keys (and thus nodes) from cluster access.
+	PrivateKey PrivateKey
+
 	// The keyring holds all of the encryption keys used internally. It is
 	// automatically initialized using the SecretKey and SecretKeys values.
 	Keyring *Keyring

--- a/encryption.go
+++ b/encryption.go
@@ -1,0 +1,260 @@
+package memberlist
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"golang.org/x/crypto/curve25519"
+)
+
+// basic implemenation, cribbed from wireguard-go
+
+// Generate a new key to use for encryption. This is a convenience wrapper
+// to provide the key in the proper format for use in Memberlist config and
+// join Addresses.
+func GenerateKey() (private string, public string, err error) {
+	pk, err := NewPrivateKey()
+	if err != nil {
+		return "", "", err
+	}
+
+	return pk.HexString(), pk.Public().HexString(), nil
+}
+
+const KeySize = 32
+
+type ParseError struct {
+	Reason string
+	Input  string
+}
+
+func (p *ParseError) Error() string {
+	return p.Reason
+}
+
+// Key is curve25519 key.
+type (
+	Key      []byte
+	KeyArray [32]byte
+)
+
+// newPresharedKey generates a new random key.
+func newPresharedKey() (Key, error) {
+	var k [KeySize]byte
+	_, err := rand.Read(k[:])
+	if err != nil {
+		return nil, err
+	}
+	return k[:], nil
+}
+
+func (k Key) MapKey() KeyArray {
+	var ka KeyArray
+	copy(ka[:], k)
+	return ka
+}
+
+func ReadRandom(size int) ([]byte, error) {
+	data := make([]byte, size)
+
+	_, err := io.ReadFull(rand.Reader, data)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func ParseHexKey(s string) (Key, error) {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return Key{}, &ParseError{"invalid hex key: " + err.Error(), s}
+	}
+	if len(b) != KeySize {
+		return Key{}, &ParseError{fmt.Sprintf("invalid hex key length: %d", len(b)), s}
+	}
+
+	var key Key
+	copy(key[:], b)
+	return key, nil
+}
+
+func ParsePrivateHexKey(v string) (PrivateKey, error) {
+	k, err := ParseHexKey(v)
+	if err != nil {
+		return PrivateKey{}, err
+	}
+	pk := PrivateKey(k)
+	if pk.IsZero() {
+		// Do not clamp a zero key, pass the zero through
+		// (much like NaN propagation) so that IsZero reports
+		// a useful result.
+		return pk, nil
+	}
+	pk.clamp()
+	return pk, nil
+}
+
+func (k Key) Base64() string    { return base64.StdEncoding.EncodeToString(k[:]) }
+func (k Key) String() string    { return "pub:" + k.Base64()[:8] }
+func (k Key) HexString() string { return hex.EncodeToString(k[:]) }
+func (k Key) Equal(k2 Key) bool { return subtle.ConstantTimeCompare(k[:], k2[:]) == 1 }
+
+func (k *Key) ShortString() string {
+	if k.IsZero() {
+		return "[empty]"
+	}
+	long := k.String()
+	if len(long) < 10 {
+		return "invalid"
+	}
+	return "[" + long[0:4] + "…" + long[len(long)-5:len(long)-1] + "]"
+}
+
+func (k Key) IsZero() bool {
+	if k == nil {
+		return true
+	}
+	var zeros Key
+	return subtle.ConstantTimeCompare(zeros[:], k[:]) == 1
+}
+
+func (k Key) Bytes() []byte {
+	if k.IsZero() {
+		return nil
+	}
+
+	return k
+}
+
+func (k Key) MarshalJSON() ([]byte, error) {
+	if k == nil {
+		return []byte("null"), nil
+	}
+	buf := new(bytes.Buffer)
+	fmt.Fprintf(buf, `"%x"`, k[:])
+	return buf.Bytes(), nil
+}
+
+func (k Key) UnmarshalJSON(b []byte) error {
+	if k == nil {
+		return errors.New("wgcfg.Key: UnmarshalJSON on nil pointer")
+	}
+	if len(b) < 3 || b[0] != '"' || b[len(b)-1] != '"' {
+		return errors.New("wgcfg.Key: UnmarshalJSON not given a string")
+	}
+	b = b[1 : len(b)-1]
+	key, err := ParseHexKey(string(b))
+	if err != nil {
+		return fmt.Errorf("wgcfg.Key: UnmarshalJSON: %v", err)
+	}
+	copy(k[:], key[:])
+	return nil
+}
+
+func (a Key) LessThan(b Key) bool {
+	for i := range a {
+		if a[i] < b[i] {
+			return true
+		} else if a[i] > b[i] {
+			return false
+		}
+	}
+	return false
+}
+
+// PrivateKey is curve25519 key.
+type PrivateKey []byte
+
+// NewPrivateKey generates a new curve25519 secret key.
+// It conforms to the format described on https://cr.yp.to/ecdh.html.
+func NewPrivateKey() (PrivateKey, error) {
+	k, err := newPresharedKey()
+	if err != nil {
+		return PrivateKey{}, err
+	}
+	k[0] &= 248
+	k[31] = (k[31] & 127) | 64
+	return (PrivateKey)(k), nil
+}
+
+func ParsePrivateKey(b64 string) (*PrivateKey, error) {
+	k, err := parseKeyBase64(base64.StdEncoding, b64)
+	return (*PrivateKey)(k), err
+}
+
+func (k PrivateKey) String() string           { return base64.StdEncoding.EncodeToString(k[:]) }
+func (k PrivateKey) HexString() string        { return hex.EncodeToString(k[:]) }
+func (k PrivateKey) Equal(k2 PrivateKey) bool { return subtle.ConstantTimeCompare(k[:], k2[:]) == 1 }
+
+func (k *PrivateKey) IsZero() bool {
+	pk := Key(*k)
+	return pk.IsZero()
+}
+
+func (k PrivateKey) clamp() {
+	k[0] &= 248
+	k[31] = (k[31] & 127) | 64
+}
+
+// Public computes the public key matching this curve25519 secret key.
+func (k PrivateKey) Public() Key {
+	pk := Key(k)
+	if pk.IsZero() {
+		panic("Tried to generate emptyPrivateKey.Public()")
+	}
+	var p, tk [KeySize]byte
+
+	copy(tk[:], k)
+	curve25519.ScalarBaseMult(&p, &tk)
+	return p[:]
+}
+
+func (k PrivateKey) MarshalText() ([]byte, error) {
+	buf := new(bytes.Buffer)
+	fmt.Fprintf(buf, `privkey:%x`, k[:])
+	return buf.Bytes(), nil
+}
+
+func (k PrivateKey) UnmarshalText(b []byte) error {
+	s := string(b)
+	if !strings.HasPrefix(s, `privkey:`) {
+		return errors.New("wgcfg.PrivateKey: UnmarshalText not given a private-key string")
+	}
+	s = strings.TrimPrefix(s, `privkey:`)
+	key, err := ParseHexKey(s)
+	if err != nil {
+		return fmt.Errorf("wgcfg.PrivateKey: UnmarshalText: %v", err)
+	}
+	copy(k[:], key[:])
+	return nil
+}
+
+func (k PrivateKey) SharedSecret(pub Key) (ss [KeySize]byte) {
+	var apk, ask [KeySize]byte
+
+	copy(apk[:], pub)
+	copy(ask[:], k)
+	curve25519.ScalarMult(&ss, &ask, &apk)
+	return ss
+}
+
+func parseKeyBase64(enc *base64.Encoding, s string) (*Key, error) {
+	k, err := enc.DecodeString(s)
+	if err != nil {
+		return nil, &ParseError{"Invalid key: " + err.Error(), s}
+	}
+	if len(k) != KeySize {
+		return nil, &ParseError{"Keys must decode to exactly 32 bytes", s}
+	}
+	var key Key
+	copy(key[:], k)
+	return &key, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529
 	github.com/stretchr/testify v1.2.2
+	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392
 )

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -112,12 +112,12 @@ func TestKeyRing_MultiKeyEncryptDecrypt(t *testing.T) {
 
 	// First encrypt using the primary key and make sure we can decrypt
 	var buf bytes.Buffer
-	err = encryptPayload(1, TestKeys[0], plaintext, extra, &buf)
+	err = encryptPayload(1, TestKeys[0], plaintext, extra, nil, &buf)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	msg, err := decryptPayload(keyring.GetKeys(), buf.Bytes(), extra)
+	msg, err := decryptPayload(nil, keyring.GetKeys(), buf.Bytes(), extra)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -128,12 +128,12 @@ func TestKeyRing_MultiKeyEncryptDecrypt(t *testing.T) {
 
 	// Now encrypt with a secondary key and try decrypting again.
 	buf.Reset()
-	err = encryptPayload(1, TestKeys[2], plaintext, extra, &buf)
+	err = encryptPayload(1, TestKeys[2], plaintext, extra, nil, &buf)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	msg, err = decryptPayload(keyring.GetKeys(), buf.Bytes(), extra)
+	msg, err = decryptPayload(nil, keyring.GetKeys(), buf.Bytes(), extra)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestKeyRing_MultiKeyEncryptDecrypt(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	msg, err = decryptPayload(keyring.GetKeys(), buf.Bytes(), extra)
+	msg, err = decryptPayload(nil, keyring.GetKeys(), buf.Bytes(), extra)
 	if err == nil {
 		t.Fatalf("Expected no keys to decrypt message")
 	}

--- a/memberlist.go
+++ b/memberlist.go
@@ -485,7 +485,7 @@ func (m *Memberlist) setAlive() error {
 		Port:        uint16(port),
 		Meta:        meta,
 		Vsn:         m.config.BuildVsnArray(),
-		PublicKey:   m.publicKey.Bytes(),
+		PublicKey:   m.publicKey,
 	}
 
 	m.aliveNode(&a, nil, true)

--- a/memberlist.go
+++ b/memberlist.go
@@ -222,9 +222,15 @@ func newMemberlist(conf *Config) (*Memberlist, error) {
 			return nil, fmt.Errorf("PKI protocol requested but no access token provided")
 		}
 
-		dhkey, err := NewPrivateKey()
-		if err != nil {
-			return nil, err
+		dhkey := conf.PrivateKey
+
+		var err error
+
+		if dhkey == nil {
+			dhkey, err = NewPrivateKey()
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		m.privateKey = dhkey

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -24,6 +25,10 @@ var bindNum byte = 10
 func getBindAddr() net.IP {
 	bindLock.Lock()
 	defer bindLock.Unlock()
+
+	if runtime.GOOS == "darwin" {
+		bindNum = 1
+	}
 
 	result := net.IPv4(127, 0, 0, bindNum)
 	bindNum++

--- a/mock_transport.go
+++ b/mock_transport.go
@@ -189,7 +189,7 @@ func (t *MockTransport) getPeer(a Address) (*MockTransport, error) {
 		dest, ok = t.net.transportsByAddr[a.Addr]
 	}
 	if !ok {
-		return nil, fmt.Errorf("No route to %s", a)
+		return nil, fmt.Errorf("No route to %s", a.String())
 	}
 	return dest, nil
 }

--- a/net.go
+++ b/net.go
@@ -3,7 +3,9 @@ package memberlist
 import (
 	"bufio"
 	"bytes"
+	"crypto/subtle"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -13,6 +15,7 @@ import (
 
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/go-msgpack/codec"
+	"golang.org/x/crypto/blake2b"
 )
 
 // This is the minimum and maximum protocol version that we can
@@ -34,7 +37,9 @@ const (
 	// understand version 4 or greater.
 	ProtocolVersion2Compatible = 2
 
-	ProtocolVersionMax = 5
+	ProtocolPKIVersion1 = 5
+
+	ProtocolVersionMax = ProtocolPKIVersion1
 )
 
 // messageType is an integer ID of a type of message that can be received
@@ -88,13 +93,16 @@ type ping struct {
 	SourceAddr []byte `codec:",omitempty"` // Source address, used for a direct reply
 	SourcePort uint16 `codec:",omitempty"` // Source port, used for a direct reply
 	SourceNode string `codec:",omitempty"` // Source name, used for a direct reply
+
+	SourcePublicKey []byte `codec:",omitempty"` // Source public key, used for direct reply
 }
 
 // indirect ping sent to an indirect node
 type indirectPingReq struct {
-	SeqNo  uint32
-	Target []byte
-	Port   uint16
+	SeqNo     uint32
+	Target    []byte
+	Port      uint16
+	PublicKey []byte `codec:",omitempty"` // The public key of the target if known
 
 	// Node is sent so the target can verify they are
 	// the intended recipient. This is to protect against an agent
@@ -106,12 +114,16 @@ type indirectPingReq struct {
 	SourceAddr []byte `codec:",omitempty"` // Source address, used for a direct reply
 	SourcePort uint16 `codec:",omitempty"` // Source port, used for a direct reply
 	SourceNode string `codec:",omitempty"` // Source name, used for a direct reply
+
+	SourcePublicKey []byte `codec:",omitempty"` // Source public key, used for direct reply
 }
 
 // ack response is sent for a ping
 type ackResp struct {
 	SeqNo   uint32
 	Payload []byte
+
+	SourcePublicKey []byte `codec:",omitempty"` // The public key of the ack sender
 }
 
 // nack response is sent for an indirect ping when the pinger doesn't hear from
@@ -145,6 +157,8 @@ type alive struct {
 	// The versions of the protocol/delegate that are being spoken, order:
 	// pmin, pmax, pcur, dmin, dmax, dcur
 	Vsn []uint8
+
+	PublicKey []byte
 }
 
 // dead is broadcast when we confirm a node is dead
@@ -178,6 +192,7 @@ type pushNodeState struct {
 	Incarnation uint32
 	State       nodeStateType
 	Vsn         []uint8 // Protocol versions
+	PublicKey   []byte
 }
 
 // compress is used to wrap an underlying payload
@@ -199,6 +214,8 @@ func (m *Memberlist) encryptionVersion() encryptionVersion {
 	switch m.ProtocolVersion() {
 	case 1:
 		return 0
+	case 5:
+		return 2
 	default:
 		return 1
 	}
@@ -226,6 +243,17 @@ func (m *Memberlist) handleConn(conn net.Conn) {
 	metrics.IncrCounter([]string{"memberlist", "tcp", "accept"}, 1)
 
 	conn.SetDeadline(time.Now().Add(m.config.TCPTimeout))
+
+	var err error
+
+	if m.encryptionVersion() == 2 {
+		conn, err = m.exchangePubKeys(conn, false)
+		if err != nil {
+			m.logger.Printf("[ERR] memberlist: Unable to negotiate stream connection: %s", err)
+			return
+		}
+	}
+
 	msgType, bufConn, dec, err := m.readStream(conn)
 	if err != nil {
 		if err != io.EOF {
@@ -290,7 +318,7 @@ func (m *Memberlist) handleConn(conn net.Conn) {
 			return
 		}
 
-		ack := ackResp{p.SeqNo, nil}
+		ack := ackResp{p.SeqNo, nil, m.publicKey[:]}
 		out, err := encode(ackRespMsg, &ack)
 		if err != nil {
 			m.logger.Printf("[ERR] memberlist: Failed to encode ack: %s", err)
@@ -321,11 +349,57 @@ func (m *Memberlist) packetListen() {
 	}
 }
 
+func (m *Memberlist) computeKey(peerpub Key) ([]byte, error) {
+	mk := peerpub.MapKey()
+
+	es, ok := m.encryptionStates[mk]
+	if !ok {
+		secret := m.privateKey.SharedSecret(peerpub)
+
+		h, err := blake2b.New256(m.config.AccessKey)
+		if err != nil {
+			panic(err)
+		}
+
+		h.Write(secret[:])
+
+		sharedKey := h.Sum(nil)
+
+		es = &encryptionState{sharedKey}
+		m.encryptionStates[mk] = es
+	}
+
+	return es.key, nil
+}
+
 func (m *Memberlist) ingestPacket(buf []byte, from net.Addr, timestamp time.Time) {
 	// Check if encryption is enabled
 	if m.config.EncryptionEnabled() {
+		var (
+			pkk []byte
+			err error
+		)
+
+		if encryptionVersion(buf[0]) == 2 {
+			var peerpub Key
+			copy(peerpub[:], buf[:KeySize])
+
+			pkk, err = m.computeKey(peerpub)
+			if err != nil {
+				panic(err)
+			}
+
+			buf = buf[KeySize:]
+		}
+
+		var keys [][]byte
+
+		if m.config.Keyring != nil {
+			keys = m.config.Keyring.GetKeys()
+		}
+
 		// Decrypt the payload
-		plain, err := decryptPayload(m.config.Keyring.GetKeys(), buf, nil)
+		plain, err := decryptPayload(pkk, keys, buf, nil)
 		if err != nil {
 			if !m.config.GossipVerifyIncoming {
 				// Treat the message as plaintext
@@ -505,8 +579,10 @@ func (m *Memberlist) handlePing(buf []byte, from net.Addr) {
 	}
 
 	a := Address{
-		Addr: addr,
-		Name: p.SourceNode,
+		Addr:      addr,
+		Name:      p.SourceNode,
+		PublicKey: p.SourcePublicKey,
+		LiveKey:   true,
 	}
 	if err := m.encodeAndSendMsg(a, ackRespMsg, &ack); err != nil {
 		m.logger.Printf("[ERR] memberlist: Failed to send ack: %s %s", err, LogAddress(from))
@@ -533,9 +609,10 @@ func (m *Memberlist) handleIndirectPing(buf []byte, from net.Addr) {
 		SeqNo: localSeqNo,
 		Node:  ind.Node,
 		// The outbound message is addressed FROM us.
-		SourceAddr: selfAddr,
-		SourcePort: selfPort,
-		SourceNode: m.config.Name,
+		SourceAddr:      selfAddr,
+		SourcePort:      selfPort,
+		SourceNode:      m.config.Name,
+		SourcePublicKey: m.publicKey,
 	}
 
 	// Forward the ack back to the requestor. If the request encodes an origin
@@ -554,10 +631,12 @@ func (m *Memberlist) handleIndirectPing(buf []byte, from net.Addr) {
 		// Try to prevent the nack if we've caught it in time.
 		close(cancelCh)
 
-		ack := ackResp{ind.SeqNo, nil}
+		ack := ackResp{ind.SeqNo, nil, m.publicKey.Bytes()}
 		a := Address{
-			Addr: indAddr,
-			Name: ind.SourceNode,
+			Addr:      indAddr,
+			Name:      ind.SourceNode,
+			PublicKey: ind.SourcePublicKey,
+			LiveKey:   true,
 		}
 		if err := m.encodeAndSendMsg(a, ackRespMsg, &ack); err != nil {
 			m.logger.Printf("[ERR] memberlist: Failed to forward ack: %s %s", err, LogStringAddress(indAddr))
@@ -568,9 +647,11 @@ func (m *Memberlist) handleIndirectPing(buf []byte, from net.Addr) {
 	// Send the ping.
 	addr := joinHostPort(net.IP(ind.Target).String(), ind.Port)
 	a := Address{
-		Addr: addr,
-		Name: ind.Node,
+		Addr:      addr,
+		Name:      ind.Node,
+		PublicKey: ind.PublicKey,
 	}
+
 	if err := m.encodeAndSendMsg(a, pingMsg, &ping); err != nil {
 		m.logger.Printf("[ERR] memberlist: Failed to send indirect ping: %s %s", err, LogStringAddress(indAddr))
 	}
@@ -584,8 +665,10 @@ func (m *Memberlist) handleIndirectPing(buf []byte, from net.Addr) {
 			case <-time.After(m.config.ProbeTimeout):
 				nack := nackResp{ind.SeqNo}
 				a := Address{
-					Addr: indAddr,
-					Name: ind.SourceNode,
+					Addr:      indAddr,
+					Name:      ind.SourceNode,
+					PublicKey: ind.SourcePublicKey,
+					LiveKey:   true,
 				}
 				if err := m.encodeAndSendMsg(a, nackRespMsg, &nack); err != nil {
 					m.logger.Printf("[ERR] memberlist: Failed to send nack: %s %s", err, LogStringAddress(indAddr))
@@ -755,10 +838,52 @@ func (m *Memberlist) rawSendMsgPacket(a Address, node *Node, msg []byte) error {
 
 	// Check if we have encryption enabled
 	if m.config.EncryptionEnabled() && m.config.GossipVerifyOutgoing {
+		primaryKey := m.config.Keyring.GetPrimaryKey()
+
+		if m.config.ProtocolVersion >= ProtocolPKIVersion1 {
+
+			// So there can be 2 keys for a node: the one we know about via our own knowledge
+			// of the nodes (and available in `node`), and one that is passed in from the message
+			// layer in `key`. If only one is available, no biggy, use it. If both are available,
+			// we check a flag in Address that will indicated if it's a "live" key, in other words one
+			// that was just observed. If it's live, we use it. If the message layer key is not live,
+			// then we trust the one in `node` with the idea being that our node database is kept
+			// up to date by having nodes send out alive updates about themselves when they come online
+			// which would mean the node database has the higher likelyhood of containing the correct key.
+
+			var addrpub, nodepub, peerpub []byte
+
+			addrpub = a.PublicKey
+			if node != nil {
+				nodepub = node.PublicKey
+			}
+
+			switch {
+			case addrpub != nil && nodepub != nil:
+				if a.LiveKey {
+					peerpub = addrpub
+				} else {
+					peerpub = nodepub
+				}
+			case addrpub != nil:
+				peerpub = addrpub
+			case nodepub != nil:
+				peerpub = nodepub
+			default:
+				m.logger.Printf("[ERR] memberlist: Attempting to send encrypted data node with no public key")
+				return fmt.Errorf("failed attempting to send encrypted data to node with no public key")
+			}
+
+			var err error
+			primaryKey, err = m.computeKey(peerpub)
+			if err != nil {
+				return err
+			}
+		}
+
 		// Encrypt the payload
 		var buf bytes.Buffer
-		primaryKey := m.config.Keyring.GetPrimaryKey()
-		err := encryptPayload(m.encryptionVersion(), primaryKey, msg, nil, &buf)
+		err := encryptPayload(m.encryptionVersion(), primaryKey, msg, nil, m.publicKey.Bytes(), &buf)
 		if err != nil {
 			m.logger.Printf("[ERR] memberlist: Encryption of message failed: %v", err)
 			return err
@@ -786,7 +911,11 @@ func (m *Memberlist) rawSendMsgStream(conn net.Conn, sendBuf []byte) error {
 
 	// Check if encryption is enabled
 	if m.config.EncryptionEnabled() && m.config.GossipVerifyOutgoing {
-		crypt, err := m.encryptLocalState(sendBuf)
+		econn, ok := conn.(*encryptedConn)
+		if !ok {
+			return fmt.Errorf("[ERROR] memberlist: encrypted required but not encryption context provided")
+		}
+		crypt, err := m.encryptLocalState(econn, sendBuf)
 		if err != nil {
 			m.logger.Printf("[ERROR] memberlist: Failed to encrypt local state: %v", err)
 			return err
@@ -818,6 +947,13 @@ func (m *Memberlist) sendUserMsg(a Address, sendBuf []byte) error {
 	}
 	defer conn.Close()
 
+	if m.encryptionVersion() == 2 {
+		conn, err = m.exchangePubKeys(conn, true)
+		if err != nil {
+			return err
+		}
+	}
+
 	bufConn := bytes.NewBuffer(nil)
 	if err := bufConn.WriteByte(byte(userMsg)); err != nil {
 		return err
@@ -835,6 +971,13 @@ func (m *Memberlist) sendUserMsg(a Address, sendBuf []byte) error {
 	return m.rawSendMsgStream(conn, bufConn.Bytes())
 }
 
+type encryptedConn struct {
+	net.Conn
+	PublicKey Key
+}
+
+var ErrBadNegotiation = errors.New("error verifying negoation")
+
 // sendAndReceiveState is used to initiate a push/pull over a stream with a
 // remote host.
 func (m *Memberlist) sendAndReceiveState(a Address, join bool) ([]pushNodeState, []byte, error) {
@@ -850,6 +993,13 @@ func (m *Memberlist) sendAndReceiveState(a Address, join bool) ([]pushNodeState,
 	defer conn.Close()
 	m.logger.Printf("[DEBUG] memberlist: Initiating push/pull sync with: %s %s", a.Name, conn.RemoteAddr())
 	metrics.IncrCounter([]string{"memberlist", "tcp", "connect"}, 1)
+
+	if m.encryptionVersion() == 2 {
+		conn, err = m.exchangePubKeys(conn, true)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
 
 	// Send our state
 	if err := m.sendLocalState(conn, join); err != nil {
@@ -943,13 +1093,26 @@ func (m *Memberlist) sendLocalState(conn net.Conn, join bool) error {
 }
 
 // encryptLocalState is used to help encrypt local state before sending
-func (m *Memberlist) encryptLocalState(sendBuf []byte) ([]byte, error) {
+func (m *Memberlist) encryptLocalState(conn *encryptedConn, sendBuf []byte) ([]byte, error) {
 	var buf bytes.Buffer
 
 	// Write the encryptMsg byte
 	buf.WriteByte(byte(encryptMsg))
 
-	// Write the size of the message
+	var (
+		key []byte
+		err error
+	)
+
+	if conn.PublicKey != nil {
+		key, err = m.computeKey(conn.PublicKey)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		key = m.config.Keyring.GetPrimaryKey()
+	}
+
 	sizeBuf := make([]byte, 4)
 	encVsn := m.encryptionVersion()
 	encLen := encryptedLength(encVsn, len(sendBuf))
@@ -957,20 +1120,32 @@ func (m *Memberlist) encryptLocalState(sendBuf []byte) ([]byte, error) {
 	buf.Write(sizeBuf)
 
 	// Write the encrypted cipher text to the buffer
-	key := m.config.Keyring.GetPrimaryKey()
-	err := encryptPayload(encVsn, key, sendBuf, buf.Bytes()[:5], &buf)
+	err = encryptPayload(encVsn, key, sendBuf, buf.Bytes()[:5], m.publicKey, &buf)
 	if err != nil {
 		return nil, err
 	}
+
 	return buf.Bytes(), nil
 }
 
 // decryptRemoteState is used to help decrypt the remote state
-func (m *Memberlist) decryptRemoteState(bufConn io.Reader) ([]byte, error) {
+func (m *Memberlist) decryptRemoteState(econn *encryptedConn, bufConn io.Reader) ([]byte, error) {
+	var (
+		pkk []byte
+		err error
+	)
+
+	if econn.PublicKey != nil {
+		pkk, err = m.computeKey(econn.PublicKey)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// Read in enough to determine message length
 	cipherText := bytes.NewBuffer(nil)
 	cipherText.WriteByte(byte(encryptMsg))
-	_, err := io.CopyN(cipherText, bufConn, 4)
+	_, err = io.CopyN(cipherText, bufConn, 4)
 	if err != nil {
 		return nil, err
 	}
@@ -993,8 +1168,13 @@ func (m *Memberlist) decryptRemoteState(bufConn io.Reader) ([]byte, error) {
 	cipherBytes := cipherText.Bytes()[5:]
 
 	// Decrypt the payload
-	keys := m.config.Keyring.GetKeys()
-	return decryptPayload(keys, cipherBytes, dataBytes)
+	var keys [][]byte
+
+	if m.config.Keyring != nil {
+		keys = m.config.Keyring.GetKeys()
+	}
+
+	return decryptPayload(pkk, keys, cipherBytes, dataBytes)
 }
 
 // readStream is used to read from a stream connection, decrypting and
@@ -1012,12 +1192,18 @@ func (m *Memberlist) readStream(conn net.Conn) (messageType, io.Reader, *codec.D
 
 	// Check if the message is encrypted
 	if msgType == encryptMsg {
+		econn, ok := conn.(*encryptedConn)
+		if !ok {
+			return 0, nil, nil,
+				fmt.Errorf("Remote state is encrypted but no encryption context is available")
+		}
+
 		if !m.config.EncryptionEnabled() {
 			return 0, nil, nil,
 				fmt.Errorf("Remote state is encrypted and encryption is not configured")
 		}
 
-		plain, err := m.decryptRemoteState(bufConn)
+		plain, err := m.decryptRemoteState(econn, bufConn)
 		if err != nil {
 			return 0, nil, nil, err
 		}
@@ -1171,6 +1357,104 @@ func (m *Memberlist) readUserMsg(bufConn io.Reader, dec *codec.Decoder) error {
 	return nil
 }
 
+/*
+ For streaming connections, exchange the public key used by the sender (initiator) and
+ receive. This exchange adds an addition access check crafted to have the following
+ properties:
+   1. The sender must prove that they have the same AccessKey. This is done without
+      the reciever sending any data related to the AccessKey, for instance an encrypted
+      payload. This is done because we have no protection from the curve25519 derived
+			encryption yet and we don't want to transmit any data that the sender could brute
+			force to find the value of the AccessKey.
+	 2. The sender must signed a random nonce, along with the public keys of both halves
+	    of the communication to continue. This prevents any replay attacks on this endpoint.
+*/
+
+func (m *Memberlist) exchangePubKeys(conn net.Conn, initiator bool) (net.Conn, error) {
+	ok := make(Key, KeySize)
+
+	if initiator {
+		_, err := conn.Write(m.publicKey)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = io.ReadFull(conn, ok)
+		if err != nil {
+			return nil, err
+		}
+
+		nonce := make([]byte, 32)
+		_, err = io.ReadFull(conn, nonce)
+		if err != nil {
+			return nil, err
+		}
+
+		h, err := blake2b.New256(m.config.AccessKey)
+		if err != nil {
+			return nil, err
+		}
+
+		h.Write(nonce)
+		h.Write(m.publicKey)
+		h.Write(ok)
+
+		sum := h.Sum(nil)
+
+		_, err = conn.Write(sum)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		nonce, err := ReadRandom(32)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = io.ReadFull(conn, ok)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = conn.Write(m.publicKey)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = conn.Write(nonce)
+		if err != nil {
+			return nil, err
+		}
+
+		remoteSum := make([]byte, blake2b.Size256)
+
+		_, err = io.ReadFull(conn, remoteSum)
+		if err != nil {
+			return nil, err
+		}
+
+		h, err := blake2b.New256(m.config.AccessKey)
+		if err != nil {
+			return nil, err
+		}
+
+		h.Write(nonce)
+		h.Write(ok)
+		h.Write(m.publicKey)
+
+		sum := h.Sum(nil)
+
+		if subtle.ConstantTimeCompare(sum, remoteSum) != 1 {
+			return nil, ErrBadNegotiation
+		}
+	}
+
+	return &encryptedConn{
+		Conn:      conn,
+		PublicKey: ok,
+	}, nil
+}
+
 // sendPingAndWaitForAck makes a stream connection to the given address, sends
 // a ping, and waits for an ack. All of this is done as a series of blocking
 // operations, given the deadline. The bool return parameter is true if we
@@ -1189,7 +1473,15 @@ func (m *Memberlist) sendPingAndWaitForAck(a Address, ping ping, deadline time.T
 		return false, nil
 	}
 	defer conn.Close()
+
 	conn.SetDeadline(deadline)
+
+	if m.encryptionVersion() == 2 {
+		conn, err = m.exchangePubKeys(conn, true)
+		if err != nil {
+			return false, err
+		}
+	}
 
 	out, err := encode(pingMsg, &ping)
 	if err != nil {

--- a/net_test.go
+++ b/net_test.go
@@ -826,7 +826,7 @@ func TestEncryptDecryptState(t *testing.T) {
 	state := []byte("this is our internal state...")
 	config := &Config{
 		SecretKey:       []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
-		ProtocolVersion: ProtocolVersionMax,
+		ProtocolVersion: ProtocolVersion2Compatible,
 	}
 	config.Logger = testLogger(t)
 

--- a/security.go
+++ b/security.go
@@ -18,7 +18,6 @@ currently support the following versions:
  0 - AES-GCM 128, using PKCS7 padding
  1 - AES-GCM 128, no padding. Padding not needed, caused bloat.
  2 - Curve25519 derived keys, AES-GCM 128, no padding.
- 3 - Same as 2 but includes the sender public key in the content
 
 */
 type encryptionVersion uint8

--- a/security.go
+++ b/security.go
@@ -17,13 +17,15 @@ currently support the following versions:
 
  0 - AES-GCM 128, using PKCS7 padding
  1 - AES-GCM 128, no padding. Padding not needed, caused bloat.
+ 2 - Curve25519 derived keys, AES-GCM 128, no padding.
+ 3 - Same as 2 but includes the sender public key in the content
 
 */
 type encryptionVersion uint8
 
 const (
 	minEncryptionVersion encryptionVersion = 0
-	maxEncryptionVersion encryptionVersion = 1
+	maxEncryptionVersion encryptionVersion = 2
 )
 
 const (
@@ -62,6 +64,8 @@ func encryptOverhead(vsn encryptionVersion) int {
 		return 45 // Version: 1, IV: 12, Padding: 16, Tag: 16
 	case 1:
 		return 29 // Version: 1, IV: 12, Tag: 16
+	case 2:
+		return 29 + KeySize
 	default:
 		panic("unsupported version")
 	}
@@ -71,8 +75,11 @@ func encryptOverhead(vsn encryptionVersion) int {
 // for a message of given length
 func encryptedLength(vsn encryptionVersion, inp int) int {
 	// If we are on version 1, there is no padding
-	if vsn >= 1 {
+	switch vsn {
+	case 1:
 		return versionSize + nonceSize + inp + tagSize
+	case 2:
+		return versionSize + nonceSize + inp + tagSize + KeySize
 	}
 
 	// Determine the padding size
@@ -85,7 +92,7 @@ func encryptedLength(vsn encryptionVersion, inp int) int {
 // encryptPayload is used to encrypt a message with a given key.
 // We make use of AES-128 in GCM mode. New byte buffer is the version,
 // nonce, ciphertext and tag
-func encryptPayload(vsn encryptionVersion, key []byte, msg []byte, data []byte, dst *bytes.Buffer) error {
+func encryptPayload(vsn encryptionVersion, key, msg, data, pubKey []byte, dst *bytes.Buffer) error {
 	// Get the AES block cipher
 	aesBlock, err := aes.NewCipher(key)
 	if err != nil {
@@ -105,6 +112,13 @@ func encryptPayload(vsn encryptionVersion, key []byte, msg []byte, data []byte, 
 	// Write the encryption version
 	dst.WriteByte(byte(vsn))
 
+	nonceStart := versionSize
+
+	if len(pubKey) > 0 {
+		dst.Write(pubKey)
+		nonceStart += KeySize
+	}
+
 	// Add a random nonce
 	io.CopyN(dst, rand.Reader, nonceSize)
 	afterNonce := dst.Len()
@@ -112,12 +126,13 @@ func encryptPayload(vsn encryptionVersion, key []byte, msg []byte, data []byte, 
 	// Ensure we are correctly padded (only version 0)
 	if vsn == 0 {
 		io.Copy(dst, bytes.NewReader(msg))
+		// We never use this with a pubkey, so these offsets are fine.
 		pkcs7encode(dst, offset+versionSize+nonceSize, aes.BlockSize)
 	}
 
 	// Encrypt message using GCM
 	slice := dst.Bytes()[offset:]
-	nonce := slice[versionSize : versionSize+nonceSize]
+	nonce := slice[nonceStart : nonceStart+nonceSize]
 
 	// Message source depends on the encryption version.
 	// Version 0 uses padding, version 1 does not
@@ -137,7 +152,7 @@ func encryptPayload(vsn encryptionVersion, key []byte, msg []byte, data []byte, 
 
 // decryptMessage performs the actual decryption of ciphertext. This is in its
 // own function to allow it to be called on all keys easily.
-func decryptMessage(key, msg []byte, data []byte) ([]byte, error) {
+func decryptMessage(key, msg []byte, data []byte, hasPubKey bool) ([]byte, error) {
 	// Get the AES block cipher
 	aesBlock, err := aes.NewCipher(key)
 	if err != nil {
@@ -153,6 +168,11 @@ func decryptMessage(key, msg []byte, data []byte) ([]byte, error) {
 	// Decrypt the message
 	nonce := msg[versionSize : versionSize+nonceSize]
 	ciphertext := msg[versionSize+nonceSize:]
+	if hasPubKey {
+		nonce = msg[versionSize+KeySize : versionSize+KeySize+nonceSize]
+		ciphertext = msg[versionSize+KeySize+nonceSize:]
+	}
+
 	plain, err := gcm.Open(nil, nonce, ciphertext, data)
 	if err != nil {
 		return nil, err
@@ -165,7 +185,7 @@ func decryptMessage(key, msg []byte, data []byte) ([]byte, error) {
 // decryptPayload is used to decrypt a message with a given key,
 // and verify it's contents. Any padding will be removed, and a
 // slice to the plaintext is returned. Decryption is done IN PLACE!
-func decryptPayload(keys [][]byte, msg []byte, data []byte) ([]byte, error) {
+func decryptPayload(pkk []byte, keys [][]byte, msg []byte, data []byte) ([]byte, error) {
 	// Ensure we have at least one byte
 	if len(msg) == 0 {
 		return nil, fmt.Errorf("Cannot decrypt empty payload")
@@ -182,8 +202,20 @@ func decryptPayload(keys [][]byte, msg []byte, data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("Payload is too small to decrypt: %d", len(msg))
 	}
 
+	if len(pkk) != 0 {
+		plain, err := decryptMessage(pkk, msg, data, vsn == 2)
+		if err == nil {
+			// Remove the PKCS7 padding for vsn 0
+			if vsn == 0 {
+				return pkcs7decode(plain, aes.BlockSize), nil
+			} else {
+				return plain, nil
+			}
+		}
+	}
+
 	for _, key := range keys {
-		plain, err := decryptMessage(key, msg, data)
+		plain, err := decryptMessage(key, msg, data, vsn == 2)
 		if err == nil {
 			// Remove the PKCS7 padding for vsn 0
 			if vsn == 0 {

--- a/security_test.go
+++ b/security_test.go
@@ -46,7 +46,7 @@ func encryptDecryptVersioned(vsn encryptionVersion, t *testing.T) {
 	extra := []byte("random data")
 
 	var buf bytes.Buffer
-	err := encryptPayload(vsn, k1, plaintext, extra, &buf)
+	err := encryptPayload(vsn, k1, plaintext, extra, nil, &buf)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -56,7 +56,7 @@ func encryptDecryptVersioned(vsn encryptionVersion, t *testing.T) {
 		t.Fatalf("output length is unexpected %d %d %d", len(plaintext), buf.Len(), expLen)
 	}
 
-	msg, err := decryptPayload([][]byte{k1}, buf.Bytes(), extra)
+	msg, err := decryptPayload(nil, [][]byte{k1}, buf.Bytes(), extra)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/state.go
+++ b/state.go
@@ -948,7 +948,7 @@ func (m *Memberlist) aliveNode(a *alive, notify chan struct{}, bootstrap bool) {
 	}
 
 	// Invoke the Alive delegate if any. This can be used to filter out
-	// alive messages based on custom logic. For example, using a cluster name.
+	// alive messages based on custom logic. For example, using a cluster name or that the node's public key is known.
 	// Using a merge delegate is not enough, as it is possible for passive
 	// cluster merging to still occur.
 	if m.config.Alive != nil {

--- a/transport.go
+++ b/transport.go
@@ -73,6 +73,15 @@ type Address struct {
 	// Name is the name of the node being addressed. This is optional but
 	// transports may require it.
 	Name string
+
+	// The public key of the destination if known. If this is nil, then
+	// when transmitting with encryption, the public key will be resolved
+	// from the nodes list
+	PublicKey Key
+
+	// Inidcates if Key was observed as being sent from the address listed, meaning
+	// it's the most recent key the address has used.
+	LiveKey bool
 }
 
 func (a *Address) String() string {


### PR DESCRIPTION
This adds the ability for nodes to encrypt traffic between them using curve 25519 keys. The model does not use a trust relationship between the nodes based on the keys, the keys are used solely to further armor the encryption as it goes over the wire. This provides protection against people being able to intercept traffic and brute force the cluster wide encryption key.

Authorization to the cluster is provided by a new AccessKey config parameter, which is mixed into the shared secret derived from the public/private keys. This provides a similar access control mechanism as the current Secret Key mechanism, but without exposing the cluster to long term brute forcing.

The private keys used by each node are generated one node start, they are not stored on disk at all. This introduces the idea of an "encryption partition", where node A might send a message to node B with node B's old public key. B will thusly reject the message and node A will observe B as being down. This is effectively the same as if B were actually down. When node B started up, it sent it's new public key in alive messages to cluster members. Alive gossiping means that eventually A will observe B's new public key and the partition will be resolved.