### PR TITLE
Configurable MetaMaxSize

### DIFF
--- a/config.go
+++ b/config.go
@@ -310,7 +310,7 @@ func DefaultLANConfig() *Config {
 		HandoffQueueDepth: 1024,
 		UDPBufferSize:     1400,
 		CIDRsAllowed:      nil, // same as allow all
-		MetaMaxSize:       defaultMetaMaxSize,
+		MetaMaxSize:       DefaultMetaMaxSize,
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -233,10 +233,14 @@ type Config struct {
 	// RequireNodeNames controls if the name of a node is required when sending
 	// a message to that node.
 	RequireNodeNames bool
+
 	// CIDRsAllowed If nil, allow any connection (default), otherwise specify all networks
 	// allowed to connect (you must specify IPv6/IPv4 separately)
 	// Using [] will block all connections.
 	CIDRsAllowed []net.IPNet
+
+	// MetaMaxSize is the maximum size for node meta data
+	MetaMaxSize int
 }
 
 // ParseCIDRs return a possible empty list of all Network that have been parsed
@@ -306,6 +310,7 @@ func DefaultLANConfig() *Config {
 		HandoffQueueDepth: 1024,
 		UDPBufferSize:     1400,
 		CIDRsAllowed:      nil, // same as allow all
+		MetaMaxSize:       defaultMetaMaxSize,
 	}
 }
 

--- a/memberlist.go
+++ b/memberlist.go
@@ -433,8 +433,8 @@ func (m *Memberlist) setAlive() error {
 	// Set any metadata from the delegate.
 	var meta []byte
 	if m.config.Delegate != nil {
-		meta = m.config.Delegate.NodeMeta(MetaMaxSize)
-		if len(meta) > MetaMaxSize {
+		meta = m.config.Delegate.NodeMeta(m.config.MetaMaxSize)
+		if len(meta) > m.config.MetaMaxSize {
 			panic("Node meta data provided is longer than the limit")
 		}
 	}
@@ -492,8 +492,8 @@ func (m *Memberlist) UpdateNode(timeout time.Duration) error {
 	// Get the node meta data
 	var meta []byte
 	if m.config.Delegate != nil {
-		meta = m.config.Delegate.NodeMeta(MetaMaxSize)
-		if len(meta) > MetaMaxSize {
+		meta = m.config.Delegate.NodeMeta(m.config.MetaMaxSize)
+		if len(meta) > m.config.MetaMaxSize {
 			panic("Node meta data provided is longer than the limit")
 		}
 	}

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -159,6 +159,13 @@ func GetMemberlist(tb testing.TB, f func(c *Config)) *Memberlist {
 	return m
 }
 
+func TestDefaultLANConfig_MetaMaxSize(t *testing.T) {
+	c := DefaultLANConfig()
+	if c.MetaMaxSize != defaultMetaMaxSize {
+		t.Fatalf("should be default: %d", defaultMetaMaxSize)
+	}
+}
+
 func TestDefaultLANConfig_protocolVersion(t *testing.T) {
 	c := DefaultLANConfig()
 	if c.ProtocolVersion != ProtocolVersion2Compatible {

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -161,8 +161,8 @@ func GetMemberlist(tb testing.TB, f func(c *Config)) *Memberlist {
 
 func TestDefaultLANConfig_MetaMaxSize(t *testing.T) {
 	c := DefaultLANConfig()
-	if c.MetaMaxSize != defaultMetaMaxSize {
-		t.Fatalf("should be default: %d", defaultMetaMaxSize)
+	if c.MetaMaxSize != DefaultMetaMaxSize {
+		t.Fatalf("should be default: %d", DefaultMetaMaxSize)
 	}
 }
 

--- a/net.go
+++ b/net.go
@@ -67,7 +67,7 @@ const (
 )
 
 const (
-	defaultMetaMaxSize     = 512 // Maximum size for node meta data
+	DefaultMetaMaxSize     = 512 // Maximum size for node meta data
 	compoundHeaderOverhead = 2   // Assumed header overhead
 	compoundOverhead       = 2   // Assumed overhead per entry in compoundHeader
 	userMsgOverhead        = 1

--- a/net.go
+++ b/net.go
@@ -67,7 +67,7 @@ const (
 )
 
 const (
-	MetaMaxSize            = 512 // Maximum size for node meta data
+	defaultMetaMaxSize     = 512 // Maximum size for node meta data
 	compoundHeaderOverhead = 2   // Assumed header overhead
 	compoundOverhead       = 2   // Assumed overhead per entry in compoundHeader
 	userMsgOverhead        = 1


### PR DESCRIPTION
Consul Enterprise uses metadata for network segments. Limiting it to
512Bytes, impacts the number of segments that can be used severely. This
limit is very conservative and will remain the default. But it should be
safe to increase that most of the time and this PR is the foundation for
that.