### PR TITLE
Add check for io.CopyN when adding random nonce

### DIFF
--- a/security.go
+++ b/security.go
@@ -106,7 +106,10 @@ func encryptPayload(vsn encryptionVersion, key []byte, msg []byte, data []byte, 
 	dst.WriteByte(byte(vsn))
 
 	// Add a random nonce
-	io.CopyN(dst, rand.Reader, nonceSize)
+	_, err = io.CopyN(dst, rand.Reader, nonceSize)
+	if err != nil {
+		return err
+	}
 	afterNonce := dst.Len()
 
 	// Ensure we are correctly padded (only version 0)


### PR DESCRIPTION
This PR adds a safety check to [`io.CopyN`](https://github.com/hashicorp/memberlist/blob/2288bf30e9c8d7b5f6549bf62e07120d72fd4b6c/security.go#L109) used in the [`encryptPayload`](https://github.com/hashicorp/memberlist/blob/2288bf30e9c8d7b5f6549bf62e07120d72fd4b6c/security.go#L88) function. If the copy fails, it will _silently_ error. Checking the error helps prevent against potential nonce reuse. 