### PR TITLE
tests: Use net.JoinHostPort()

### DIFF
--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -1362,7 +1363,7 @@ func TestMemberlist_Join_DeadNode(t *testing.T) {
 	// Create a second "node", which is just a TCP listener that
 	// does not ever respond. This is to test our deadlines
 	addr2 := getBindAddr()
-	list, err := net.Listen("tcp", fmt.Sprintf("%s:%d", addr2.String(), bindPort))
+	list, err := net.Listen("tcp", net.JoinHostPort(addr2.String(), strconv.Itoa(bindPort)))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/net_test.go
+++ b/net_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -447,7 +448,7 @@ func TestTCPPushPull(t *testing.T) {
 		StateChange: time.Now().Add(-1 * time.Second),
 	})
 
-	addr := fmt.Sprintf("%s:%d", m.config.BindAddr, m.config.BindPort)
+	addr := net.JoinHostPort(m.config.BindAddr, strconv.Itoa(m.config.BindPort))
 	conn, err := net.Dial("tcp", addr)
 	if err != nil {
 		t.Fatalf("unexpected err %s", err)


### PR DESCRIPTION
While starting to look at how memberlist is used by a project, I was
browsing around and happened to notice these lines that manually
joined the bind address and port.  While it's not actually causing a
problem with these tests, it's good practice to always use
net.JoinHostPort() to do this, which will ensure that IPv6 addresses
are handled correctly.