### PR TITLE
memberlist.Logger Interface, More Flexible Logger Replacement

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -57,7 +57,7 @@ func (m *Memberlist) encodeAndBroadcast(node string, msgType messageType, msg in
 func (m *Memberlist) encodeBroadcastNotify(node string, msgType messageType, msg interface{}, notify chan struct{}) {
 	buf, err := encode(msgType, msg)
 	if err != nil {
-		m.logger.Printf("[ERR] memberlist: Failed to encode message for broadcast: %s", err)
+		m.logger.Errorf("Failed to encode message for broadcast: %s", err)
 	} else {
 		m.queueBroadcast(node, buf.Bytes(), notify)
 	}

--- a/config.go
+++ b/config.go
@@ -3,7 +3,6 @@ package memberlist
 import (
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
 	"strings"
@@ -209,7 +208,7 @@ type Config struct {
 	// this for the internal logger. If Logger is not set, it will fall back to the
 	// behavior for using LogOutput. You cannot specify both LogOutput and Logger
 	// at the same time.
-	Logger *log.Logger
+	Logger Logger
 
 	// Size of Memberlist's internal channel which handles UDP messages. The
 	// size of this determines the size of the queue which Memberlist will keep

--- a/integ_test.go
+++ b/integ_test.go
@@ -2,7 +2,6 @@ package memberlist
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"testing"
 	"time"
@@ -42,7 +41,7 @@ func TestMemberlist_Integ(t *testing.T) {
 		c.GossipInterval = 20 * time.Millisecond
 		c.PushPullInterval = 200 * time.Millisecond
 		c.SecretKey = secret
-		c.Logger = log.New(os.Stderr, c.Name, log.LstdFlags)
+		c.Logger = newNamedLoggerImpl(os.Stderr, c.Name)
 
 		if i == 0 {
 			c.Events = &ChannelEventDelegate{eventCh}

--- a/logging.go
+++ b/logging.go
@@ -2,8 +2,56 @@ package memberlist
 
 import (
 	"fmt"
+	"io"
+	"log"
 	"net"
+	"os"
 )
+
+type Logger interface {
+	Debugf(format string, v ...interface{})
+	Infof(format string, v ...interface{})
+	Warnf(format string, v ...interface{})
+	Errorf(format string, v ...interface{})
+}
+
+type loggerImpl struct{
+	logger *log.Logger
+}
+
+func newLoggerImpl(output io.Writer) Logger {
+	return newNamedLoggerImpl(output, "")
+}
+
+func newNamedLoggerImpl(output io.Writer, name string) Logger {
+	return newNamedFlagsLoggerImpl(output, name, log.LstdFlags)
+}
+
+func newNamedFlagsLoggerImpl(output io.Writer, name string, flags int) Logger {
+	var logger *log.Logger
+	if output != nil {
+		logger = log.New(os.Stderr, name, flags)
+	} else {
+		logger = log.New(output, name, flags)
+	}
+	return &loggerImpl{logger}
+}
+
+func (l *loggerImpl) Debugf(format string, v ...interface{}) {
+	l.logger.Printf("[DEBUG] memberlist: " + format, v...)
+}
+
+func (l *loggerImpl) Infof(format string, v ...interface{}) {
+	l.logger.Printf("[INFO] memberlist: " + format, v...)
+}
+
+func (l *loggerImpl) Warnf(format string, v ...interface{}) {
+	l.logger.Printf("[WARN] memberlist: " + format, v...)
+}
+
+func (l *loggerImpl) Errorf(format string, v ...interface{}) {
+	l.logger.Printf("[ERROR] memberlist: " + format, v...)
+}
 
 func LogAddress(addr net.Addr) string {
 	if addr == nil {

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"reflect"
@@ -47,7 +46,7 @@ func testConfigNet(tb testing.TB, network byte) *Config {
 	config.Name = config.BindAddr
 	config.BindPort = 0 // choose free port
 	config.RequireNodeNames = true
-	config.Logger = log.New(os.Stderr, config.Name, log.LstdFlags)
+	config.Logger = newNamedLoggerImpl(os.Stderr, config.Name)
 	return config
 }
 
@@ -288,7 +287,7 @@ func TestCreate_keyringAndSecretKey(t *testing.T) {
 func TestCreate_invalidLoggerSettings(t *testing.T) {
 	c := DefaultLANConfig()
 	c.BindAddr = getBindAddr().String()
-	c.Logger = log.New(ioutil.Discard, "", log.LstdFlags)
+	c.Logger = newLoggerImpl(ioutil.Discard)
 	c.LogOutput = ioutil.Discard
 
 	m, err := Create(c)
@@ -1488,7 +1487,7 @@ func TestMemberlist_Join_IPv6(t *testing.T) {
 	c1.Name = "A"
 	c1.BindAddr = "[::1]"
 	c1.BindPort = 0 // choose free
-	c1.Logger = log.New(os.Stderr, c1.Name, log.LstdFlags)
+	c1.Logger = newNamedLoggerImpl(os.Stderr, c1.Name)
 
 	m1, err := Create(c1)
 	require.NoError(t, err)
@@ -1499,7 +1498,7 @@ func TestMemberlist_Join_IPv6(t *testing.T) {
 	c2.Name = "B"
 	c2.BindAddr = "[::1]"
 	c2.BindPort = 0 // choose free
-	c2.Logger = log.New(os.Stderr, c2.Name, log.LstdFlags)
+	c2.Logger = newNamedLoggerImpl(os.Stderr, c2.Name)
 
 	m2, err := Create(c2)
 	require.NoError(t, err)
@@ -1787,7 +1786,7 @@ func TestMemberlist_EncryptedGossipTransition(t *testing.T) {
 		// Set the gossip interval fast enough to get a reasonable test,
 		// but slow enough to avoid "sendto: operation not permitted"
 		conf.GossipInterval = 100 * time.Millisecond
-		conf.Logger = log.New(os.Stderr, shortName, log.LstdFlags)
+		conf.Logger = newNamedLoggerImpl(os.Stderr, shortName)
 
 		pretty[conf.Name] = shortName
 		return conf

--- a/net_test.go
+++ b/net_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"reflect"
 	"strconv"
@@ -780,8 +779,7 @@ func TestIngestPacket_CRC(t *testing.T) {
 	in[1] <<= 1
 
 	logs := &bytes.Buffer{}
-	logger := log.New(logs, "", 0)
-	m.logger = logger
+	m.logger = newLoggerImpl(logs)
 	m.ingestPacket(in, udp.LocalAddr(), time.Now())
 
 	if !strings.Contains(logs.String(), "invalid checksum") {
@@ -801,8 +799,7 @@ func TestIngestPacket_ExportedFunc_EmptyMessage(t *testing.T) {
 	emptyConn := &emptyReadNetConn{}
 
 	logs := &bytes.Buffer{}
-	logger := log.New(logs, "", 0)
-	m.logger = logger
+	m.logger = newNamedFlagsLoggerImpl(logs, "", 0)
 
 	type ingestionAwareTransport interface {
 		IngestPacket(conn net.Conn, addr net.Addr, now time.Time, shouldClose bool) error

--- a/net_transport.go
+++ b/net_transport.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -34,7 +33,7 @@ type NetTransportConfig struct {
 	BindPort int
 
 	// Logger is a logger for operator messages.
-	Logger *log.Logger
+	Logger Logger
 }
 
 // NetTransport is a Transport implementation that uses connectionless UDP for
@@ -43,7 +42,7 @@ type NetTransport struct {
 	config       *NetTransportConfig
 	packetCh     chan *Packet
 	streamCh     chan net.Conn
-	logger       *log.Logger
+	logger       Logger
 	wg           sync.WaitGroup
 	tcpListeners []*net.TCPListener
 	udpListeners []*net.UDPConn
@@ -302,7 +301,7 @@ func (t *NetTransport) tcpListen(tcpLn *net.TCPListener) {
 				loopDelay = maxDelay
 			}
 
-			t.logger.Printf("[ERR] memberlist: Error accepting TCP connection: %v", err)
+			t.logger.Errorf("Error accepting TCP connection: %v", err)
 			time.Sleep(loopDelay)
 			continue
 		}
@@ -328,14 +327,14 @@ func (t *NetTransport) udpListen(udpLn *net.UDPConn) {
 				break
 			}
 
-			t.logger.Printf("[ERR] memberlist: Error reading UDP packet: %v", err)
+			t.logger.Errorf("Error reading UDP packet: %v", err)
 			continue
 		}
 
 		// Check the length - it needs to have at least one byte to be a
 		// proper message.
 		if n < 1 {
-			t.logger.Printf("[ERR] memberlist: UDP packet too short (%d bytes) %s",
+			t.logger.Errorf("UDP packet too short (%d bytes) %s",
 				len(buf), LogAddress(addr))
 			continue
 		}

--- a/state_test.go
+++ b/state_test.go
@@ -3,7 +3,6 @@ package memberlist
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"reflect"
@@ -24,7 +23,7 @@ func HostMemberlist(host string, t *testing.T, f func(*Config)) *Memberlist {
 	c.Name = host
 	c.BindAddr = host
 	c.BindPort = 0 // choose a free port
-	c.Logger = log.New(os.Stderr, host, log.LstdFlags)
+	c.Logger = newNamedLoggerImpl(os.Stderr, host)
 	if f != nil {
 		f(c)
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,7 +1,6 @@
 package memberlist
 
 import (
-	"log"
 	"net"
 	"strings"
 	"sync/atomic"
@@ -141,7 +140,7 @@ type testCountingWriter struct {
 
 func (tw testCountingWriter) Write(p []byte) (n int, err error) {
 	atomic.AddInt32(tw.numCalls, 1)
-	if !strings.Contains(string(p), "memberlist: Error accepting TCP connection") {
+	if !strings.Contains(string(p), "Error accepting TCP connection") {
 		tw.t.Error("did not receive expected log message")
 	}
 	tw.t.Log("countingWriter:", string(p))
@@ -160,7 +159,7 @@ func TestTransport_TcpListenBackoff(t *testing.T) {
 
 	var numCalls int32
 	countingWriter := testCountingWriter{t, &numCalls}
-	countingLogger := log.New(countingWriter, "test", log.LstdFlags)
+	countingLogger := newNamedLoggerImpl(countingWriter, "test")
 	transport := NetTransport{
 		streamCh: make(chan net.Conn),
 		logger:   countingLogger,


### PR DESCRIPTION
Implemented a `memberlist.Logger` interface, allowing for more flexible logger library replacement (we use `logrus`). Also removes a bunch of `[LEVEL] memberlist:` boilerplate from log messages.

Care was taken to handle all of the logging specializations in the test cases.