### PR TITLE
Prevent a couple panics on malformed input

### DIFF
--- a/net.go
+++ b/net.go
@@ -355,6 +355,10 @@ func (m *Memberlist) ingestPacket(buf []byte, from net.Addr, timestamp time.Time
 }
 
 func (m *Memberlist) handleCommand(buf []byte, from net.Addr, timestamp time.Time) {
+	if len(buf) < 1 {
+		m.logger.Printf("[ERR] memberlist: missing message type byte %s", LogAddress(from))
+		return
+	}
 	// Decode the message type
 	msgType := messageType(buf[0])
 	buf = buf[1:]

--- a/net_test.go
+++ b/net_test.go
@@ -866,3 +866,12 @@ func listenUDP(t *testing.T) *net.UDPConn {
 	}
 	return udp
 }
+
+func TestHandleCommand(t *testing.T) {
+	var buf bytes.Buffer
+	m := Memberlist{
+		logger: log.New(&buf, "", 0),
+	}
+	m.handleCommand(nil, &net.TCPAddr{Port: 12345}, time.Now())
+	require.Contains(t, buf.String(), "missing message type byte")
+}

--- a/util.go
+++ b/util.go
@@ -185,18 +185,18 @@ func decodeCompoundMessage(buf []byte) (trunc int, parts [][]byte, err error) {
 		err = fmt.Errorf("missing compound length byte")
 		return
 	}
-	numParts := uint8(buf[0])
+	numParts := int(buf[0])
 	buf = buf[1:]
 
 	// Check we have enough bytes
-	if len(buf) < int(numParts*2) {
+	if len(buf) < numParts*2 {
 		err = fmt.Errorf("truncated len slice")
 		return
 	}
 
 	// Decode the lengths
 	lengths := make([]uint16, numParts)
-	for i := 0; i < int(numParts); i++ {
+	for i := 0; i < numParts; i++ {
 		lengths[i] = binary.BigEndian.Uint16(buf[i*2 : i*2+2])
 	}
 	buf = buf[numParts*2:]
@@ -204,7 +204,7 @@ func decodeCompoundMessage(buf []byte) (trunc int, parts [][]byte, err error) {
 	// Split each message
 	for idx, msgLen := range lengths {
 		if len(buf) < int(msgLen) {
-			trunc = int(numParts) - idx
+			trunc = numParts - idx
 			return
 		}
 

--- a/util_test.go
+++ b/util_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestUtil_PortFunctions(t *testing.T) {
@@ -312,6 +314,13 @@ func TestDecodeCompoundMessage(t *testing.T) {
 			t.Fatalf("bad part len")
 		}
 	}
+}
+
+func TestDecodeCompoundMessage_NumberOfPartsOverflow(t *testing.T) {
+	buf := []byte{0x80}
+	_, _, err := decodeCompoundMessage(buf)
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "truncated len slice")
 }
 
 func TestDecodeCompoundMessage_Trunc(t *testing.T) {


### PR DESCRIPTION
Fix two possible panics that could be caused by malformed input of compound messages or compressed messages.

The two tests that were added both panicked without these code changes.