### PR TITLE
Fix for compound messages containing >255 messages.

### DIFF
--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -1200,9 +1200,9 @@ func TestMemberlist_UserData(t *testing.T) {
 
 	bindPort := m1.config.BindPort
 
-	bcasts := [][]byte{
-		[]byte("test"),
-		[]byte("foobar"),
+	bcasts := make([][]byte, 256)
+	for i := range bcasts {
+		bcasts[i] = []byte(fmt.Sprintf("%d", i))
 	}
 
 	// Create a second node

--- a/state.go
+++ b/state.go
@@ -606,10 +606,12 @@ func (m *Memberlist) gossip() {
 				m.logger.Printf("[ERR] memberlist: Failed to send gossip to %s: %s", addr, err)
 			}
 		} else {
-			// Otherwise create and send a compound message
-			compound := makeCompoundMessage(msgs)
-			if err := m.rawSendMsgPacket(node.FullAddress(), &node, compound.Bytes()); err != nil {
-				m.logger.Printf("[ERR] memberlist: Failed to send gossip to %s: %s", addr, err)
+			// Otherwise create and send one or more compound messages
+			compounds := makeCompoundMessages(msgs)
+			for _, compound := range compounds {
+				if err := m.rawSendMsgPacket(node.FullAddress(), &node, compound.Bytes()); err != nil {
+					m.logger.Printf("[ERR] memberlist: Failed to send gossip to %s: %s", addr, err)
+				}
 			}
 		}
 	}

--- a/util.go
+++ b/util.go
@@ -152,6 +152,23 @@ OUTER:
 	return kNodes
 }
 
+// makeCompoundMessages takes a list of messages and packs
+// them into one or multiple messages based on the limitations
+// of compound messages (255 messages each).
+func makeCompoundMessages(msgs [][]byte) []*bytes.Buffer {
+	const maxMsgs = 255
+	bufs := make([]*bytes.Buffer, 0, (len(msgs)+(maxMsgs-1))/maxMsgs)
+
+	for ; len(msgs) > maxMsgs; msgs = msgs[maxMsgs:] {
+		bufs = append(bufs, makeCompoundMessage(msgs[:maxMsgs]))
+	}
+	if len(msgs) > 0 {
+		bufs = append(bufs, makeCompoundMessage(msgs))
+	}
+
+	return bufs
+}
+
 // makeCompoundMessage takes a list of messages and generates
 // a single compound message containing all of them
 func makeCompoundMessage(msgs [][]byte) *bytes.Buffer {


### PR DESCRIPTION
If ever more than 255 messages are put into a compound message, then the resulting packet will be malformed leading to errors on the receiving end such as:

```
Failed to decode ping request: codec.decoder: Only encoded map or array can be decoded into a struct. (valueType: 2)
```

This change sends multiple packets if required. The alternative approach would be to limit the number of messages that `GetBroadcasts` can return, by e.g. passing in a maximum number of messages, but this would require changing the `Delegate` interface, possibly breaking downstream code.
