### PR TITLE
Fix udp writes not causing nodes to become suspect

### DIFF
--- a/state.go
+++ b/state.go
@@ -274,6 +274,11 @@ func failedRemote(err error) bool {
 			case "dial", "read", "write":
 				return true
 			}
+		} else if strings.HasPrefix(t.Net, "udp") {
+			switch t.Op {
+			case "write":
+				return true
+			}
 		}
 	}
 	return false

--- a/state_test.go
+++ b/state_test.go
@@ -2218,6 +2218,8 @@ func TestMemberlist_FailedRemote(t *testing.T) {
 		{"net.OpError for tcp with dial", &net.OpError{Net: "tcp", Op: "dial"}, true},
 		{"net.OpError for tcp with write", &net.OpError{Net: "tcp", Op: "write"}, true},
 		{"net.OpError for tcp with read", &net.OpError{Net: "tcp", Op: "read"}, true},
+		{"net.OpError for udp with write", &net.OpError{Net: "udp", Op: "write"}, true},
+		{"net.OpError for udp with read", &net.OpError{Net: "udp", Op: "read"}, false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
failedRemote only checks for TCP failures but probeNode uses
UDP meaning that if we get a "network is unreachable" during
a UDP write the node is never marked as suspect.

This failure mode can be reproduced by bringing down an
interface in which case the node will show its neighbors
as alive while all other nodes will properly detect the
node as failed.

For reproduction steps see: https://gist.github.com/Austinpayne/defc5178bc2cc5c29ff5ada3dc4b1260
For verifying the fix see: https://gist.github.com/Austinpayne/151876ba8841be46484ce71664ced6bc