### PR TITLE
add an optional wrapper labels to packets and streams

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   go:
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.15
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.16
     environment:
       - TEST_RESULTS: /tmp/test-results # path to where test results are saved
 

--- a/config.go
+++ b/config.go
@@ -28,6 +28,10 @@ type Config struct {
 	// authenticated data.
 	Label string
 
+	// SkipInboundLabelCheck skips the check that inbound packets and gossip
+	// streams need to be label prefixed.
+	SkipInboundLabelCheck bool
+
 	// Configuration related to what address to bind to and ports to
 	// listen on. The port is used for both UDP and TCP gossip. It is
 	// assumed other nodes are running on this port, but they do not need

--- a/config.go
+++ b/config.go
@@ -21,6 +21,13 @@ type Config struct {
 	// make a NetTransport using BindAddr and BindPort from this structure.
 	Transport Transport
 
+	// Label is an optional set of bytes to include on the outside of each
+	// packet and stream.
+	//
+	// If gossip encryption is enabled and this is set it is treated as GCM
+	// authenticated data.
+	Label string
+
 	// Configuration related to what address to bind to and ports to
 	// listen on. The port is used for both UDP and TCP gossip. It is
 	// assumed other nodes are running on this port, but they do not need

--- a/label.go
+++ b/label.go
@@ -1,0 +1,173 @@
+package memberlist
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+)
+
+// General approach is to prefix all packets and streams with the same structure:
+//
+// magic type byte (244): uint8
+// length of label name:  uint8 (because labels can't be longer than 255 bytes)
+// label name:            []uint8
+
+// LabelMaxSize is the maximum length of a packet or stream label.
+const LabelMaxSize = 255
+
+// AddLabelHeaderToPacket prefixes outgoing packets with the correct header if
+// the label is not empty.
+func AddLabelHeaderToPacket(buf []byte, label string) ([]byte, error) {
+	if label == "" {
+		return buf, nil
+	}
+	if len(label) > LabelMaxSize {
+		return nil, fmt.Errorf("label %q is too long", label)
+	}
+
+	newBuf := make([]byte, 2, 2+len(label)+len(buf))
+	newBuf[0] = byte(hasLabelMsg)
+	newBuf[1] = byte(len(label))
+	newBuf = append(newBuf, []byte(label)...)
+	newBuf = append(newBuf, []byte(buf)...)
+	return newBuf, nil
+}
+
+// RemoveLabelHeaderFromPacket removes any label header from the provided
+// packet and returns it along with the remaining packet contents.
+func RemoveLabelHeaderFromPacket(buf []byte) (newBuf []byte, label string, err error) {
+	if len(buf) < 1 {
+		return buf, "", nil // can't possibly be labeled
+	}
+
+	// [type:byte] [size:byte] [size bytes]
+
+	msgType := messageType(buf[0])
+	if msgType != hasLabelMsg {
+		return buf, "", nil
+	}
+
+	if len(buf) < 3 {
+		return nil, "", fmt.Errorf("cannot decode label; packet has been truncated")
+	}
+
+	size := int(buf[1])
+	if size < 1 {
+		return nil, "", fmt.Errorf("label header cannot be empty when present")
+	}
+
+	if len(buf) < 2+size {
+		return nil, "", fmt.Errorf("cannot decode label; packet has been truncated")
+	}
+
+	label = string(buf[2 : 2+size])
+	newBuf = buf[2+size:]
+
+	return newBuf, label, nil
+}
+
+// AddLabelHeaderToStream prefixes outgoing streams with the correct header if
+// the label is not empty.
+func AddLabelHeaderToStream(conn net.Conn, label string) error {
+	if label == "" {
+		return nil
+	}
+	if len(label) > LabelMaxSize {
+		return fmt.Errorf("label %q is too long", label)
+	}
+
+	header := make([]byte, 2, 2+len(label))
+	header[0] = byte(hasLabelMsg)
+	header[1] = byte(len(label))
+	header = append(header, []byte(label)...)
+
+	_, err := conn.Write(header)
+	return err
+}
+
+// RemoveLabelHeaderFromStream removes any label header from the beginning of
+// the stream if present and returns it along with an updated conn with that
+// header removed.
+//
+// Note that on error it is the caller's responsibility to close the
+// connection.
+func RemoveLabelHeaderFromStream(conn net.Conn) (net.Conn, string, error) {
+	br := bufio.NewReader(conn)
+
+	// First check for the type byte.
+	peeked, err := br.Peek(1)
+	if err != nil {
+		if err == io.EOF {
+			conn, err = newPeekedConnFromBufferedReader(conn, br, 0)
+			return conn, "", err
+		}
+		return nil, "", err
+	}
+
+	msgType := messageType(peeked[0])
+	if msgType != hasLabelMsg {
+		conn, err = newPeekedConnFromBufferedReader(conn, br, 0)
+		return conn, "", err
+	}
+
+	// We are guaranteed to get a size byte as well.
+	peeked, err = br.Peek(2)
+	if err != nil {
+		if err == io.EOF {
+			return nil, "", fmt.Errorf("cannot decode label; stream has been truncated")
+		}
+		return nil, "", err
+	}
+
+	size := int(peeked[1])
+	if size < 1 {
+		return nil, "", fmt.Errorf("label header cannot be empty when present")
+	}
+	// NOTE: we don't have to check this against LabelMaxSize because a byte
+	// already has a max value of 255.
+
+	// Once we know the size we can peek the label as well. Note that since we
+	// are using the default bufio.Reader size of 4096, the entire label header
+	// fits in the initial buffer fill so this should be free.
+	peeked, err = br.Peek(2 + size)
+	if err != nil {
+		if err == io.EOF {
+			return nil, "", fmt.Errorf("cannot decode label; stream has been truncated")
+		}
+		return nil, "", err
+	}
+
+	label := string(peeked[2 : 2+size])
+
+	conn, err = newPeekedConnFromBufferedReader(conn, br, 2+size)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return conn, label, nil
+}
+
+// newPeekedConnFromBufferedReader will splice the buffer contents after the
+// offset into the provided net.Conn and return the result so that the rest of
+// the buffer contents are returned first when reading from the returned
+// peekedConn before moving on to the unbuffered conn contents.
+func newPeekedConnFromBufferedReader(conn net.Conn, br *bufio.Reader, offset int) (*peekedConn, error) {
+	// Extract any of the readahead buffer.
+	peeked, err := br.Peek(br.Buffered())
+	if err != nil {
+		return nil, err
+	}
+
+	return &peekedConn{
+		Peeked: peeked[offset:],
+		Conn:   conn,
+	}, nil
+}
+
+func labelOverhead(label string) int {
+	if label == "" {
+		return 0
+	}
+	return 2 + len(label)
+}

--- a/label.go
+++ b/label.go
@@ -37,7 +37,7 @@ func AddLabelHeaderToPacket(buf []byte, label string) ([]byte, error) {
 // RemoveLabelHeaderFromPacket removes any label header from the provided
 // packet and returns it along with the remaining packet contents.
 func RemoveLabelHeaderFromPacket(buf []byte) (newBuf []byte, label string, err error) {
-	if len(buf) < 1 {
+	if len(buf) == 0 {
 		return buf, "", nil // can't possibly be labeled
 	}
 

--- a/label.go
+++ b/label.go
@@ -99,8 +99,10 @@ func RemoveLabelHeaderFromStream(conn net.Conn) (net.Conn, string, error) {
 	peeked, err := br.Peek(1)
 	if err != nil {
 		if err == io.EOF {
-			conn, err = newPeekedConnFromBufferedReader(conn, br, 0)
-			return conn, "", err
+			// It is safe to return the original net.Conn at this point because
+			// it never contained any data in the first place so we don't have
+			// to splice the buffer into the conn because both are empty.
+			return conn, "", nil
 		}
 		return nil, "", err
 	}

--- a/label_test.go
+++ b/label_test.go
@@ -1,0 +1,364 @@
+package memberlist
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddLabelHeaderToPacket(t *testing.T) {
+	type testcase struct {
+		buf          []byte
+		label        string
+		expectPacket []byte
+		expectErr    string
+	}
+
+	run := func(t *testing.T, tc testcase) {
+		got, err := AddLabelHeaderToPacket(tc.buf, tc.label)
+		if tc.expectErr != "" {
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.expectErr)
+		} else {
+			require.NoError(t, err)
+			require.Equal(t, tc.expectPacket, got)
+		}
+	}
+
+	longLabel := strings.Repeat("a", 255)
+
+	cases := map[string]testcase{
+		"nil buf with no label": testcase{
+			buf:          nil,
+			label:        "",
+			expectPacket: nil,
+		},
+		"nil buf with label": testcase{
+			buf:          nil,
+			label:        "foo",
+			expectPacket: append([]byte{byte(hasLabelMsg), 3}, []byte("foo")...),
+		},
+		"message with label": testcase{
+			buf:          []byte("something"),
+			label:        "foo",
+			expectPacket: append([]byte{byte(hasLabelMsg), 3}, []byte("foosomething")...),
+		},
+		"message with no label": testcase{
+			buf:          []byte("something"),
+			label:        "",
+			expectPacket: []byte("something"),
+		},
+		"message with almost too long label": testcase{
+			buf:          []byte("something"),
+			label:        longLabel,
+			expectPacket: append([]byte{byte(hasLabelMsg), 255}, []byte(longLabel+"something")...),
+		},
+		"label too long by one byte": testcase{
+			buf:       []byte("something"),
+			label:     longLabel + "x",
+			expectErr: `label "` + longLabel + `x" is too long`,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func TestRemoveLabelHeaderFromPacket(t *testing.T) {
+	type testcase struct {
+		buf          []byte
+		expectLabel  string
+		expectPacket []byte
+		expectErr    string
+	}
+
+	run := func(t *testing.T, tc testcase) {
+		gotBuf, gotLabel, err := RemoveLabelHeaderFromPacket(tc.buf)
+		if tc.expectErr != "" {
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.expectErr)
+		} else {
+			require.NoError(t, err)
+			require.Equal(t, tc.expectPacket, gotBuf)
+			require.Equal(t, tc.expectLabel, gotLabel)
+		}
+	}
+
+	cases := map[string]testcase{
+		"empty buf": testcase{
+			buf:          []byte{},
+			expectLabel:  "",
+			expectPacket: []byte{},
+		},
+		"ping with no label": testcase{
+			buf:          buildBuffer(t, pingMsg, "blah"),
+			expectLabel:  "",
+			expectPacket: buildBuffer(t, pingMsg, "blah"),
+		},
+		"error with no label": testcase{ // 2021-10: largest standard message type
+			buf:          buildBuffer(t, errMsg, "blah"),
+			expectLabel:  "",
+			expectPacket: buildBuffer(t, errMsg, "blah"),
+		},
+		"v1 encrypt with no label": testcase{ // 2021-10: highest encryption version
+			buf:          buildBuffer(t, maxEncryptionVersion, "blah"),
+			expectLabel:  "",
+			expectPacket: buildBuffer(t, maxEncryptionVersion, "blah"),
+		},
+		"buf too small for label": testcase{
+			buf:       buildBuffer(t, hasLabelMsg, "x"),
+			expectErr: `cannot decode label; packet has been truncated`,
+		},
+		"buf too small for label size": testcase{
+			buf:       buildBuffer(t, hasLabelMsg),
+			expectErr: `cannot decode label; packet has been truncated`,
+		},
+		"label empty": testcase{
+			buf:       buildBuffer(t, hasLabelMsg, 0, "x"),
+			expectErr: `label header cannot be empty when present`,
+		},
+		"label truncated": testcase{
+			buf:       buildBuffer(t, hasLabelMsg, 2, "x"),
+			expectErr: `cannot decode label; packet has been truncated`,
+		},
+		"ping with label": testcase{
+			buf:          buildBuffer(t, hasLabelMsg, 3, "abc", pingMsg, "blah"),
+			expectLabel:  "abc",
+			expectPacket: buildBuffer(t, pingMsg, "blah"),
+		},
+		"error with label": testcase{ // 2021-10: largest standard message type
+			buf:          buildBuffer(t, hasLabelMsg, 3, "abc", errMsg, "blah"),
+			expectLabel:  "abc",
+			expectPacket: buildBuffer(t, errMsg, "blah"),
+		},
+		"v1 encrypt with label": testcase{ // 2021-10: highest encryption version
+			buf:          buildBuffer(t, hasLabelMsg, 3, "abc", maxEncryptionVersion, "blah"),
+			expectLabel:  "abc",
+			expectPacket: buildBuffer(t, maxEncryptionVersion, "blah"),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func TestAddLabelHeaderToStream(t *testing.T) {
+	type testcase struct {
+		label      string
+		expectData []byte
+		expectErr  string
+	}
+
+	suffixData := "EXTRA DATA"
+
+	run := func(t *testing.T, tc testcase) {
+		server, client := net.Pipe()
+		defer server.Close()
+		defer client.Close()
+
+		var (
+			dataCh = make(chan []byte, 1)
+			errCh  = make(chan error, 1)
+		)
+		go func() {
+			var buf bytes.Buffer
+			_, err := io.Copy(&buf, server)
+			if err != nil {
+				errCh <- err
+			}
+			dataCh <- buf.Bytes()
+		}()
+
+		err := AddLabelHeaderToStream(client, tc.label)
+		if tc.expectErr != "" {
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.expectErr)
+			return
+		}
+		require.NoError(t, err)
+
+		client.Write([]byte(suffixData))
+		client.Close()
+
+		expect := make([]byte, 0, len(suffixData)+len(tc.expectData))
+		expect = append(expect, tc.expectData...)
+		expect = append(expect, suffixData...)
+
+		select {
+		case err := <-errCh:
+			require.NoError(t, err)
+		case got := <-dataCh:
+			require.Equal(t, expect, got)
+		}
+	}
+
+	longLabel := strings.Repeat("a", 255)
+
+	cases := map[string]testcase{
+		"no label": testcase{
+			label:      "",
+			expectData: nil,
+		},
+		"with label": testcase{
+			label:      "foo",
+			expectData: buildBuffer(t, hasLabelMsg, 3, "foo"),
+		},
+		"almost too long label": testcase{
+			label:      longLabel,
+			expectData: buildBuffer(t, hasLabelMsg, 255, longLabel),
+		},
+		"label too long by one byte": testcase{
+			label:     longLabel + "x",
+			expectErr: `label "` + longLabel + `x" is too long`,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func TestRemoveLabelHeaderFromStream(t *testing.T) {
+	type testcase struct {
+		buf         []byte
+		expectLabel string
+		expectData  []byte
+		expectErr   string
+	}
+
+	run := func(t *testing.T, tc testcase) {
+		server, client := net.Pipe()
+		defer server.Close()
+		defer client.Close()
+
+		var (
+			errCh = make(chan error, 1)
+		)
+		go func() {
+			_, err := server.Write(tc.buf)
+			if err != nil {
+				errCh <- err
+			}
+			server.Close()
+		}()
+
+		newConn, gotLabel, err := RemoveLabelHeaderFromStream(client)
+		if tc.expectErr != "" {
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.expectErr)
+			return
+		}
+		require.NoError(t, err)
+
+		gotBuf, err := io.ReadAll(newConn)
+		require.NoError(t, err)
+
+		require.Equal(t, tc.expectData, gotBuf)
+		require.Equal(t, tc.expectLabel, gotLabel)
+	}
+
+	cases := map[string]testcase{
+		"empty buf": testcase{
+			buf:         []byte{},
+			expectLabel: "",
+			expectData:  []byte{},
+		},
+		"ping with no label": testcase{
+			buf:         buildBuffer(t, pingMsg, "blah"),
+			expectLabel: "",
+			expectData:  buildBuffer(t, pingMsg, "blah"),
+		},
+		"error with no label": testcase{ // 2021-10: largest standard message type
+			buf:         buildBuffer(t, errMsg, "blah"),
+			expectLabel: "",
+			expectData:  buildBuffer(t, errMsg, "blah"),
+		},
+		"v1 encrypt with no label": testcase{ // 2021-10: highest encryption version
+			buf:         buildBuffer(t, maxEncryptionVersion, "blah"),
+			expectLabel: "",
+			expectData:  buildBuffer(t, maxEncryptionVersion, "blah"),
+		},
+		"buf too small for label": testcase{
+			buf:       buildBuffer(t, hasLabelMsg, "x"),
+			expectErr: `cannot decode label; stream has been truncated`,
+		},
+		"buf too small for label size": testcase{
+			buf:       buildBuffer(t, hasLabelMsg),
+			expectErr: `cannot decode label; stream has been truncated`,
+		},
+		"label empty": testcase{
+			buf:       buildBuffer(t, hasLabelMsg, 0, "x"),
+			expectErr: `label header cannot be empty when present`,
+		},
+		"label truncated": testcase{
+			buf:       buildBuffer(t, hasLabelMsg, 2, "x"),
+			expectErr: `cannot decode label; stream has been truncated`,
+		},
+		"ping with label": testcase{
+			buf:         buildBuffer(t, hasLabelMsg, 3, "abc", pingMsg, "blah"),
+			expectLabel: "abc",
+			expectData:  buildBuffer(t, pingMsg, "blah"),
+		},
+		"error with label": testcase{ // 2021-10: largest standard message type
+			buf:         buildBuffer(t, hasLabelMsg, 3, "abc", errMsg, "blah"),
+			expectLabel: "abc",
+			expectData:  buildBuffer(t, errMsg, "blah"),
+		},
+		"v1 encrypt with label": testcase{ // 2021-10: highest encryption version
+			buf:         buildBuffer(t, hasLabelMsg, 3, "abc", maxEncryptionVersion, "blah"),
+			expectLabel: "abc",
+			expectData:  buildBuffer(t, maxEncryptionVersion, "blah"),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func buildBuffer(t *testing.T, stuff ...interface{}) []byte {
+	var buf bytes.Buffer
+	for _, item := range stuff {
+		switch x := item.(type) {
+		case int:
+			x2 := uint(x)
+			if x2 > 255 {
+				t.Fatalf("int is too big")
+			}
+			buf.WriteByte(byte(x2))
+		case byte:
+			buf.WriteByte(byte(x))
+		case messageType:
+			buf.WriteByte(byte(x))
+		case encryptionVersion:
+			buf.WriteByte(byte(x))
+		case string:
+			buf.Write([]byte(x))
+		case []byte:
+			buf.Write(x)
+		default:
+			t.Fatalf("unexpected type %T", item)
+		}
+	}
+	return buf.Bytes()
+}
+
+func TestLabelOverhead(t *testing.T) {
+	require.Equal(t, 0, labelOverhead(""))
+	require.Equal(t, 3, labelOverhead("a"))
+	require.Equal(t, 9, labelOverhead("abcdefg"))
+}

--- a/memberlist.go
+++ b/memberlist.go
@@ -187,6 +187,17 @@ func newMemberlist(conf *Config) (*Memberlist, error) {
 		nodeAwareTransport = &shimNodeAwareTransport{transport}
 	}
 
+	if len(conf.Label) > LabelMaxSize {
+		return nil, fmt.Errorf("could not use %q as a label: too long", conf.Label)
+	}
+
+	if conf.Label != "" {
+		nodeAwareTransport = &labelWrappedTransport{
+			label:              conf.Label,
+			NodeAwareTransport: nodeAwareTransport,
+		}
+	}
+
 	m := &Memberlist{
 		config:               conf,
 		shutdownCh:           make(chan struct{}),
@@ -262,7 +273,7 @@ func (m *Memberlist) Join(existing []string) (int, error) {
 			hp := joinHostPort(addr.ip.String(), addr.port)
 			a := Address{Addr: hp, Name: addr.nodeName}
 			if err := m.pushPullNode(a, true); err != nil {
-				err = fmt.Errorf("Failed to join %s: %v", addr.ip, err)
+				err = fmt.Errorf("Failed to join %s: %v", a.Addr, err)
 				errs = multierror.Append(errs, err)
 				m.logger.Printf("[DEBUG] memberlist: %v", err)
 				continue

--- a/net.go
+++ b/net.go
@@ -42,6 +42,9 @@ const (
 type messageType uint8
 
 // The list of available message types.
+//
+// WARNING: ONLY APPEND TO THIS LIST! The numeric values are part of the
+// protocol itself.
 const (
 	pingMsg messageType = iota
 	indirectPingMsg
@@ -57,6 +60,13 @@ const (
 	nackRespMsg
 	hasCrcMsg
 	errMsg
+)
+
+const (
+	// hasLabelMsg has a deliberately high value so that you can disambiguate
+	// it from the encryptionVersion header which is either 0/1 right now and
+	// also any of the existing messageTypes
+	hasLabelMsg messageType = 244
 )
 
 // compressionType is used to specify the compression algorithm
@@ -226,7 +236,23 @@ func (m *Memberlist) handleConn(conn net.Conn) {
 	metrics.IncrCounter([]string{"memberlist", "tcp", "accept"}, 1)
 
 	conn.SetDeadline(time.Now().Add(m.config.TCPTimeout))
-	msgType, bufConn, dec, err := m.readStream(conn)
+
+	var (
+		streamLabel string
+		err         error
+	)
+	conn, streamLabel, err = RemoveLabelHeaderFromStream(conn)
+	if err != nil {
+		m.logger.Printf("[ERR] memberlist: failed to receive and remove the stream label header: %s %s", err, LogConn(conn))
+		return
+	}
+
+	if m.config.Label != streamLabel {
+		m.logger.Printf("[ERR] memberlist: discarding stream with unacceptable label %q: %s", streamLabel, LogConn(conn))
+		return
+	}
+
+	msgType, bufConn, dec, err := m.readStream(conn, streamLabel)
 	if err != nil {
 		if err != io.EOF {
 			m.logger.Printf("[ERR] memberlist: failed to receive: %s %s", err, LogConn(conn))
@@ -238,7 +264,7 @@ func (m *Memberlist) handleConn(conn net.Conn) {
 				return
 			}
 
-			err = m.rawSendMsgStream(conn, out.Bytes())
+			err = m.rawSendMsgStream(conn, out.Bytes(), streamLabel)
 			if err != nil {
 				m.logger.Printf("[ERR] memberlist: Failed to send error: %s %s", err, LogConn(conn))
 				return
@@ -269,7 +295,7 @@ func (m *Memberlist) handleConn(conn net.Conn) {
 			return
 		}
 
-		if err := m.sendLocalState(conn, join); err != nil {
+		if err := m.sendLocalState(conn, join, streamLabel); err != nil {
 			m.logger.Printf("[ERR] memberlist: Failed to push local state: %s %s", err, LogConn(conn))
 			return
 		}
@@ -297,7 +323,7 @@ func (m *Memberlist) handleConn(conn net.Conn) {
 			return
 		}
 
-		err = m.rawSendMsgStream(conn, out.Bytes())
+		err = m.rawSendMsgStream(conn, out.Bytes(), streamLabel)
 		if err != nil {
 			m.logger.Printf("[ERR] memberlist: Failed to send ack: %s %s", err, LogConn(conn))
 			return
@@ -322,10 +348,26 @@ func (m *Memberlist) packetListen() {
 }
 
 func (m *Memberlist) ingestPacket(buf []byte, from net.Addr, timestamp time.Time) {
+	var (
+		packetLabel string
+		err         error
+	)
+	buf, packetLabel, err = RemoveLabelHeaderFromPacket(buf)
+	if err != nil {
+		m.logger.Printf("[ERR] memberlist: %v %s", err, LogAddress(from))
+		return
+	}
+
+	if m.config.Label != packetLabel {
+		m.logger.Printf("[ERR] memberlist: discarding packet with unacceptable label %q: %s", packetLabel, LogAddress(from))
+		return
+	}
+
 	// Check if encryption is enabled
 	if m.config.EncryptionEnabled() {
 		// Decrypt the payload
-		plain, err := decryptPayload(m.config.Keyring.GetKeys(), buf, nil)
+		authData := []byte(packetLabel)
+		plain, err := decryptPayload(m.config.Keyring.GetKeys(), buf, authData)
 		if err != nil {
 			if !m.config.GossipVerifyIncoming {
 				// Treat the message as plaintext
@@ -723,7 +765,7 @@ func (m *Memberlist) encodeAndSendMsg(a Address, msgType messageType, msg interf
 // opportunistically create a compoundMsg and piggy back other broadcasts.
 func (m *Memberlist) sendMsg(a Address, msg []byte) error {
 	// Check if we can piggy back any messages
-	bytesAvail := m.config.UDPBufferSize - len(msg) - compoundHeaderOverhead
+	bytesAvail := m.config.UDPBufferSize - len(msg) - compoundHeaderOverhead - labelOverhead(m.config.Label)
 	if m.config.EncryptionEnabled() && m.config.GossipVerifyOutgoing {
 		bytesAvail -= encryptOverhead(m.encryptionVersion())
 	}
@@ -795,9 +837,12 @@ func (m *Memberlist) rawSendMsgPacket(a Address, node *Node, msg []byte) error {
 	// Check if we have encryption enabled
 	if m.config.EncryptionEnabled() && m.config.GossipVerifyOutgoing {
 		// Encrypt the payload
-		var buf bytes.Buffer
-		primaryKey := m.config.Keyring.GetPrimaryKey()
-		err := encryptPayload(m.encryptionVersion(), primaryKey, msg, nil, &buf)
+		var (
+			primaryKey  = m.config.Keyring.GetPrimaryKey()
+			packetLabel = []byte(m.config.Label)
+			buf         bytes.Buffer
+		)
+		err := encryptPayload(m.encryptionVersion(), primaryKey, msg, packetLabel, &buf)
 		if err != nil {
 			m.logger.Printf("[ERR] memberlist: Encryption of message failed: %v", err)
 			return err
@@ -812,7 +857,7 @@ func (m *Memberlist) rawSendMsgPacket(a Address, node *Node, msg []byte) error {
 
 // rawSendMsgStream is used to stream a message to another host without
 // modification, other than applying compression and encryption if enabled.
-func (m *Memberlist) rawSendMsgStream(conn net.Conn, sendBuf []byte) error {
+func (m *Memberlist) rawSendMsgStream(conn net.Conn, sendBuf []byte, streamLabel string) error {
 	// Check if compression is enabled
 	if m.config.EnableCompression {
 		compBuf, err := compressPayload(sendBuf)
@@ -825,7 +870,7 @@ func (m *Memberlist) rawSendMsgStream(conn net.Conn, sendBuf []byte) error {
 
 	// Check if encryption is enabled
 	if m.config.EncryptionEnabled() && m.config.GossipVerifyOutgoing {
-		crypt, err := m.encryptLocalState(sendBuf)
+		crypt, err := m.encryptLocalState(sendBuf, streamLabel)
 		if err != nil {
 			m.logger.Printf("[ERROR] memberlist: Failed to encrypt local state: %v", err)
 			return err
@@ -871,7 +916,8 @@ func (m *Memberlist) sendUserMsg(a Address, sendBuf []byte) error {
 	if _, err := bufConn.Write(sendBuf); err != nil {
 		return err
 	}
-	return m.rawSendMsgStream(conn, bufConn.Bytes())
+
+	return m.rawSendMsgStream(conn, bufConn.Bytes(), m.config.Label)
 }
 
 // sendAndReceiveState is used to initiate a push/pull over a stream with a
@@ -891,12 +937,12 @@ func (m *Memberlist) sendAndReceiveState(a Address, join bool) ([]pushNodeState,
 	metrics.IncrCounter([]string{"memberlist", "tcp", "connect"}, 1)
 
 	// Send our state
-	if err := m.sendLocalState(conn, join); err != nil {
+	if err := m.sendLocalState(conn, join, m.config.Label); err != nil {
 		return nil, nil, err
 	}
 
 	conn.SetDeadline(time.Now().Add(m.config.TCPTimeout))
-	msgType, bufConn, dec, err := m.readStream(conn)
+	msgType, bufConn, dec, err := m.readStream(conn, m.config.Label)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -921,7 +967,7 @@ func (m *Memberlist) sendAndReceiveState(a Address, join bool) ([]pushNodeState,
 }
 
 // sendLocalState is invoked to send our local state over a stream connection.
-func (m *Memberlist) sendLocalState(conn net.Conn, join bool) error {
+func (m *Memberlist) sendLocalState(conn net.Conn, join bool, streamLabel string) error {
 	// Setup a deadline
 	conn.SetDeadline(time.Now().Add(m.config.TCPTimeout))
 
@@ -978,11 +1024,11 @@ func (m *Memberlist) sendLocalState(conn net.Conn, join bool) error {
 	}
 
 	// Get the send buffer
-	return m.rawSendMsgStream(conn, bufConn.Bytes())
+	return m.rawSendMsgStream(conn, bufConn.Bytes(), streamLabel)
 }
 
 // encryptLocalState is used to help encrypt local state before sending
-func (m *Memberlist) encryptLocalState(sendBuf []byte) ([]byte, error) {
+func (m *Memberlist) encryptLocalState(sendBuf []byte, streamLabel string) ([]byte, error) {
 	var buf bytes.Buffer
 
 	// Write the encryptMsg byte
@@ -995,9 +1041,15 @@ func (m *Memberlist) encryptLocalState(sendBuf []byte) ([]byte, error) {
 	binary.BigEndian.PutUint32(sizeBuf, uint32(encLen))
 	buf.Write(sizeBuf)
 
+	// Authenticated Data is:
+	//
+	//   [messageType; byte] [messageLength; uint32] [stream_label; optional]
+	//
+	dataBytes := appendBytes(buf.Bytes()[:5], []byte(streamLabel))
+
 	// Write the encrypted cipher text to the buffer
 	key := m.config.Keyring.GetPrimaryKey()
-	err := encryptPayload(encVsn, key, sendBuf, buf.Bytes()[:5], &buf)
+	err := encryptPayload(encVsn, key, sendBuf, dataBytes, &buf)
 	if err != nil {
 		return nil, err
 	}
@@ -1005,7 +1057,7 @@ func (m *Memberlist) encryptLocalState(sendBuf []byte) ([]byte, error) {
 }
 
 // decryptRemoteState is used to help decrypt the remote state
-func (m *Memberlist) decryptRemoteState(bufConn io.Reader) ([]byte, error) {
+func (m *Memberlist) decryptRemoteState(bufConn io.Reader, streamLabel string) ([]byte, error) {
 	// Read in enough to determine message length
 	cipherText := bytes.NewBuffer(nil)
 	cipherText.WriteByte(byte(encryptMsg))
@@ -1027,8 +1079,13 @@ func (m *Memberlist) decryptRemoteState(bufConn io.Reader) ([]byte, error) {
 		return nil, err
 	}
 
-	// Decrypt the cipherText
-	dataBytes := cipherText.Bytes()[:5]
+	// Decrypt the cipherText with some authenticated data
+	//
+	// Authenticated Data is:
+	//
+	//   [messageType; byte] [messageLength; uint32] [label_data; optional]
+	//
+	dataBytes := appendBytes(cipherText.Bytes()[:5], []byte(streamLabel))
 	cipherBytes := cipherText.Bytes()[5:]
 
 	// Decrypt the payload
@@ -1036,15 +1093,18 @@ func (m *Memberlist) decryptRemoteState(bufConn io.Reader) ([]byte, error) {
 	return decryptPayload(keys, cipherBytes, dataBytes)
 }
 
-// readStream is used to read from a stream connection, decrypting and
+// readStream is used to read messages from a stream connection, decrypting and
 // decompressing the stream if necessary.
-func (m *Memberlist) readStream(conn net.Conn) (messageType, io.Reader, *codec.Decoder, error) {
+//
+// The provided streamLabel if present will be authenticated during decryption
+// of each message.
+func (m *Memberlist) readStream(conn net.Conn, streamLabel string) (messageType, io.Reader, *codec.Decoder, error) {
 	// Created a buffered reader
 	var bufConn io.Reader = bufio.NewReader(conn)
 
 	// Read the message type
 	buf := [1]byte{0}
-	if _, err := bufConn.Read(buf[:]); err != nil {
+	if _, err := io.ReadFull(bufConn, buf[:]); err != nil {
 		return 0, nil, nil, err
 	}
 	msgType := messageType(buf[0])
@@ -1056,7 +1116,7 @@ func (m *Memberlist) readStream(conn net.Conn) (messageType, io.Reader, *codec.D
 				fmt.Errorf("Remote state is encrypted and encryption is not configured")
 		}
 
-		plain, err := m.decryptRemoteState(bufConn)
+		plain, err := m.decryptRemoteState(bufConn, streamLabel)
 		if err != nil {
 			return 0, nil, nil, err
 		}
@@ -1236,11 +1296,11 @@ func (m *Memberlist) sendPingAndWaitForAck(a Address, ping ping, deadline time.T
 		return false, err
 	}
 
-	if err = m.rawSendMsgStream(conn, out.Bytes()); err != nil {
+	if err = m.rawSendMsgStream(conn, out.Bytes(), m.config.Label); err != nil {
 		return false, err
 	}
 
-	msgType, _, dec, err := m.readStream(conn)
+	msgType, _, dec, err := m.readStream(conn, m.config.Label)
 	if err != nil {
 		return false, err
 	}

--- a/net.go
+++ b/net.go
@@ -247,6 +247,15 @@ func (m *Memberlist) handleConn(conn net.Conn) {
 		return
 	}
 
+	if m.config.SkipInboundLabelCheck {
+		if streamLabel != "" {
+			m.logger.Printf("[ERR] memberlist: unexpected double stream label header: %s", LogConn(conn))
+			return
+		}
+		// Set this from config so that the auth data assertions work below.
+		streamLabel = m.config.Label
+	}
+
 	if m.config.Label != streamLabel {
 		m.logger.Printf("[ERR] memberlist: discarding stream with unacceptable label %q: %s", streamLabel, LogConn(conn))
 		return
@@ -356,6 +365,15 @@ func (m *Memberlist) ingestPacket(buf []byte, from net.Addr, timestamp time.Time
 	if err != nil {
 		m.logger.Printf("[ERR] memberlist: %v %s", err, LogAddress(from))
 		return
+	}
+
+	if m.config.SkipInboundLabelCheck {
+		if packetLabel != "" {
+			m.logger.Printf("[ERR] memberlist: unexpected double packet label header: %s", LogAddress(from))
+			return
+		}
+		// Set this from config so that the auth data assertions work below.
+		packetLabel = m.config.Label
 	}
 
 	if m.config.Label != packetLabel {

--- a/net_test.go
+++ b/net_test.go
@@ -302,7 +302,7 @@ func TestTCPPing(t *testing.T) {
 		}
 		defer conn.Close()
 
-		msgType, _, dec, err := m.readStream(conn)
+		msgType, _, dec, err := m.readStream(conn, "")
 		if err != nil {
 			pingErrCh <- fmt.Errorf("failed to read ping: %s", err)
 			return
@@ -336,7 +336,7 @@ func TestTCPPing(t *testing.T) {
 			return
 		}
 
-		err = m.rawSendMsgStream(conn, out.Bytes())
+		err = m.rawSendMsgStream(conn, out.Bytes(), "")
 		if err != nil {
 			pingErrCh <- fmt.Errorf("failed to send ack: %s", err)
 			return
@@ -365,7 +365,7 @@ func TestTCPPing(t *testing.T) {
 		}
 		defer conn.Close()
 
-		_, _, dec, err := m.readStream(conn)
+		_, _, dec, err := m.readStream(conn, "")
 		if err != nil {
 			pingErrCh <- fmt.Errorf("failed to read ping: %s", err)
 			return
@@ -384,7 +384,7 @@ func TestTCPPing(t *testing.T) {
 			return
 		}
 
-		err = m.rawSendMsgStream(conn, out.Bytes())
+		err = m.rawSendMsgStream(conn, out.Bytes(), "")
 		if err != nil {
 			pingErrCh <- fmt.Errorf("failed to send ack: %s", err)
 			return
@@ -413,7 +413,7 @@ func TestTCPPing(t *testing.T) {
 		}
 		defer conn.Close()
 
-		_, _, _, err = m.readStream(conn)
+		_, _, _, err = m.readStream(conn, "")
 		if err != nil {
 			pingErrCh <- fmt.Errorf("failed to read ping: %s", err)
 			return
@@ -426,7 +426,7 @@ func TestTCPPing(t *testing.T) {
 			return
 		}
 
-		err = m.rawSendMsgStream(conn, out.Bytes())
+		err = m.rawSendMsgStream(conn, out.Bytes(), "")
 		if err != nil {
 			pingErrCh <- fmt.Errorf("failed to send bogus msg: %s", err)
 			return
@@ -697,7 +697,7 @@ func TestEncryptDecryptState(t *testing.T) {
 	}
 	defer m.Shutdown()
 
-	crypt, err := m.encryptLocalState(state)
+	crypt, err := m.encryptLocalState(state, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -706,7 +706,7 @@ func TestEncryptDecryptState(t *testing.T) {
 	buf := bytes.NewReader(crypt)
 	buf.Seek(1, 0)
 
-	plain, err := m.decryptRemoteState(buf)
+	plain, err := m.decryptRemoteState(buf, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/peeked_conn.go
+++ b/peeked_conn.go
@@ -1,0 +1,48 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Originally from: https://github.com/google/tcpproxy/blob/master/tcpproxy.go
+// at f5c09fbedceb69e4b238dec52cdf9f2fe9a815e2
+
+package memberlist
+
+import "net"
+
+// peekedConn is an incoming connection that has had some bytes read from it
+// to determine how to route the connection. The Read method stitches
+// the peeked bytes and unread bytes back together.
+type peekedConn struct {
+	// Peeked are the bytes that have been read from Conn for the
+	// purposes of route matching, but have not yet been consumed
+	// by Read calls. It set to nil by Read when fully consumed.
+	Peeked []byte
+
+	// Conn is the underlying connection.
+	// It can be type asserted against *net.TCPConn or other types
+	// as needed. It should not be read from directly unless
+	// Peeked is nil.
+	net.Conn
+}
+
+func (c *peekedConn) Read(p []byte) (n int, err error) {
+	if len(c.Peeked) > 0 {
+		n = copy(p, c.Peeked)
+		c.Peeked = c.Peeked[n:]
+		if len(c.Peeked) == 0 {
+			c.Peeked = nil
+		}
+		return n, nil
+	}
+	return c.Conn.Read(p)
+}

--- a/security.go
+++ b/security.go
@@ -199,3 +199,22 @@ func decryptPayload(keys [][]byte, msg []byte, data []byte) ([]byte, error) {
 
 	return nil, fmt.Errorf("No installed keys could decrypt the message")
 }
+
+func appendBytes(first []byte, second []byte) []byte {
+	hasFirst := len(first) > 0
+	hasSecond := len(second) > 0
+
+	switch {
+	case hasFirst && hasSecond:
+		out := make([]byte, 0, len(first)+len(second))
+		out = append(out, first...)
+		out = append(out, second...)
+		return out
+	case hasFirst:
+		return first
+	case hasSecond:
+		return second
+	default:
+		return nil
+	}
+}

--- a/state.go
+++ b/state.go
@@ -592,7 +592,7 @@ func (m *Memberlist) gossip() {
 	m.nodeLock.RUnlock()
 
 	// Compute the bytes available
-	bytesAvail := m.config.UDPBufferSize - compoundHeaderOverhead
+	bytesAvail := m.config.UDPBufferSize - compoundHeaderOverhead - labelOverhead(m.config.Label)
 	if m.config.EncryptionEnabled() {
 		bytesAvail -= encryptOverhead(m.encryptionVersion())
 	}


### PR DESCRIPTION
Introduce an optional packet and stream prefix labeling concept to assist with multiplexing gossip over single ports.

Also bumps to build and test against go 1.16