### PR TITLE
Adding the regular emitting of the memberlist broadcast queue

### DIFF
--- a/config.go
+++ b/config.go
@@ -253,6 +253,10 @@ type Config struct {
 
 	// MetricLabels is a map of optional labels to apply to all metrics emitted.
 	MetricLabels []metrics.Label
+
+	// QueueCheckInterval is the interval at which we check the message
+	// queue to apply the warning and max depth.
+	QueueCheckInterval time.Duration
 }
 
 // ParseCIDRs return a possible empty list of all Network that have been parsed
@@ -322,6 +326,8 @@ func DefaultLANConfig() *Config {
 		HandoffQueueDepth: 1024,
 		UDPBufferSize:     1400,
 		CIDRsAllowed:      nil, // same as allow all
+
+		QueueCheckInterval: 30 * time.Second,
 	}
 }
 

--- a/memberlist.go
+++ b/memberlist.go
@@ -233,7 +233,7 @@ func newMemberlist(conf *Config) (*Memberlist, error) {
 	go m.streamListen()
 	go m.packetListen()
 	go m.packetHandler()
-	go m.checkQueueDepth("Intent", m.broadcasts)
+	go m.checkBroadcastQueueDepth()
 	return m, nil
 }
 
@@ -778,14 +778,14 @@ func (m *Memberlist) changeNode(addr string, f func(*nodeState)) {
 	f(n)
 }
 
-// checkQueueDepth periodically checks the size of a queue to see if
-// it is too large
-func (m *Memberlist) checkQueueDepth(name string, queue *TransmitLimitedQueue) {
+// checkBroadcastQueueDepth periodically checks the size of the broadcast queue
+// to see if it is too large
+func (m *Memberlist) checkBroadcastQueueDepth() {
 	for {
 		select {
 		case <-time.After(m.config.QueueCheckInterval):
-			numq := queue.NumQueued()
-			metrics.AddSampleWithLabels([]string{"memberlist", "queue", name}, float32(numq), m.metricLabels)
+			numq := m.broadcasts.NumQueued()
+			metrics.AddSampleWithLabels([]string{"memberlist", "queue", "broadcast"}, float32(numq), m.metricLabels)
 		case <-m.shutdownCh:
 			return
 		}

--- a/memberlist.go
+++ b/memberlist.go
@@ -785,7 +785,7 @@ func (m *Memberlist) checkBroadcastQueueDepth() {
 		select {
 		case <-time.After(m.config.QueueCheckInterval):
 			numq := m.broadcasts.NumQueued()
-			metrics.AddSampleWithLabels([]string{"memberlist", "queue", "broadcast"}, float32(numq), m.metricLabels)
+			metrics.AddSampleWithLabels([]string{"memberlist", "queue", "broadcasts"}, float32(numq), m.metricLabels)
 		case <-m.shutdownCh:
 			return
 		}

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -246,6 +246,28 @@ func TestCreate_secretKeyEmpty(t *testing.T) {
 	}
 }
 
+func TestCreate_checkBroadcastQueueMetrics(t *testing.T) {
+	sink := registerInMemorySink(t)
+	c := DefaultLANConfig()
+	c.QueueCheckInterval = 1 * time.Second
+	c.BindAddr = getBindAddr().String()
+	c.SecretKey = make([]byte, 0)
+
+	m, err := Create(c)
+	require.NoError(t, err)
+	defer m.Shutdown()
+
+	time.Sleep(3 * time.Second)
+
+	intv := getIntervalMetrics(t, sink)
+	sampleName := "consul.usage.test.memberlist.queue.broadcasts"
+	actualSample := intv.Samples[sampleName]
+
+	if actualSample.Count == 0 {
+		t.Fatalf("%s sample not taken", sampleName)
+	}
+}
+
 func TestCreate_keyringOnly(t *testing.T) {
 	c := DefaultLANConfig()
 	c.BindAddr = getBindAddr().String()

--- a/state_test.go
+++ b/state_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/armon/go-metrics"
 	iretry "github.com/hashicorp/memberlist/internal/retry"
 	"github.com/stretchr/testify/require"
 )
@@ -2392,4 +2393,22 @@ func testVerifyProtocolSingle(t *testing.T, A [][6]uint8, B [][6]uint8, expect b
 	if (err == nil) != expect {
 		t.Fatalf("bad:\nA: %v\nB: %v\nErr: %s", A, B, err)
 	}
+}
+
+func registerInMemorySink(t *testing.T) *metrics.InmemSink {
+	t.Helper()
+	// Only have a single interval for the test
+	sink := metrics.NewInmemSink(1*time.Minute, 1*time.Minute)
+	cfg := metrics.DefaultConfig("consul.usage.test")
+	cfg.EnableHostname = false
+	metrics.NewGlobal(cfg, sink)
+	return sink
+}
+
+func getIntervalMetrics(t *testing.T, sink *metrics.InmemSink) *metrics.IntervalMetrics {
+	t.Helper()
+	intervals := sink.Data()
+	require.Len(t, intervals, 1)
+	intv := intervals[0]
+	return intv
 }


### PR DESCRIPTION
## Implementation
This implementation follows the pattern that exists in [serf](https://github.com/hashicorp/serf/blob/830be12c38e509faa64a2a650629e91c8930a040/serf/serf.go#L432) for capturing intent queue metrics.  

## Verification
I verified this change by following the [Layer 7 Observability Learn Guide](https://learn.hashicorp.com/tutorials/consul/kubernetes-layer7-observability) to run prometheus and Grafana and view the metrics in a Grafana Dashboard.

### Before
Below you can see that `consul_memberlist_queue_Intent` (this has since been renamed to `consul_memberlist_queue_broadcast`) is not available as a metric.

<img width="1062" alt="Screen Shot 2022-08-25 at 4 40 44 PM" src="https://user-images.githubusercontent.com/2481360/186781494-caa726e4-a185-45a3-aa4e-280e68be0b0f.png">

### After
Below you can see that `consul_memberlist_queue_Intent` (this has since been renamed to `consul_memberlist_queue_broadcast`) is available as a metric and is showing data in the dashboard.
<img width="1051" alt="Screen Shot 2022-08-25 at 4 33 37 PM" src="https://user-images.githubusercontent.com/2481360/186781480-4b5579a4-05ae-4369-b851-ba60e1e4cf0a.png">