### PR TITLE
Emit metrics for local memberlist size and remote memberlist size

### DIFF
--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -260,7 +260,7 @@ func TestCreate_checkBroadcastQueueMetrics(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	sampleName := "consul.usage.test.memberlist.queue.broadcasts"
-	verifySamplesExists(t, []string{sampleName}, sink)
+	verifySampleExists(t, sampleName, sink)
 }
 
 func TestCreate_keyringOnly(t *testing.T) {

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -260,7 +260,7 @@ func TestCreate_checkBroadcastQueueMetrics(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	sampleName := "consul.usage.test.memberlist.queue.broadcasts"
-	verifySampleExists(t, sampleName, sink)
+	verifySamplesExists(t, []string{sampleName}, sink)
 }
 
 func TestCreate_keyringOnly(t *testing.T) {

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -259,13 +259,8 @@ func TestCreate_checkBroadcastQueueMetrics(t *testing.T) {
 
 	time.Sleep(3 * time.Second)
 
-	intv := getIntervalMetrics(t, sink)
 	sampleName := "consul.usage.test.memberlist.queue.broadcasts"
-	actualSample := intv.Samples[sampleName]
-
-	if actualSample.Count == 0 {
-		t.Fatalf("%s sample not taken", sampleName)
-	}
+	verifySampleExists(t, sampleName, sink)
 }
 
 func TestCreate_keyringOnly(t *testing.T) {

--- a/net.go
+++ b/net.go
@@ -1042,6 +1042,9 @@ func (m *Memberlist) sendLocalState(conn net.Conn, join bool, streamLabel string
 		}
 	}
 
+	moreBytes := binary.BigEndian.Uint32(bufConn.Bytes()[1:5])
+	metrics.AddSampleWithLabels([]string{"memberlist", "size", "local"}, float32(moreBytes), m.metricLabels)
+
 	// Get the send buffer
 	return m.rawSendMsgStream(conn, bufConn.Bytes(), streamLabel)
 }
@@ -1088,6 +1091,8 @@ func (m *Memberlist) decryptRemoteState(bufConn io.Reader, streamLabel string) (
 	// Ensure we aren't asked to download too much. This is to guard against
 	// an attack vector where a huge amount of state is sent
 	moreBytes := binary.BigEndian.Uint32(cipherText.Bytes()[1:5])
+	metrics.AddSampleWithLabels([]string{"memberlist", "size", "remote"}, float32(moreBytes), m.metricLabels)
+
 	if moreBytes > maxPushStateBytes {
 		return nil, fmt.Errorf("Remote node state is larger than limit (%d)", moreBytes)
 

--- a/net.go
+++ b/net.go
@@ -1043,7 +1043,7 @@ func (m *Memberlist) sendLocalState(conn net.Conn, join bool, streamLabel string
 	}
 
 	moreBytes := binary.BigEndian.Uint32(bufConn.Bytes()[1:5])
-	metrics.AddSampleWithLabels([]string{"memberlist", "size", "local"}, float32(moreBytes), m.metricLabels)
+	metrics.SetGaugeWithLabels([]string{"memberlist", "size", "local"}, float32(moreBytes), m.metricLabels)
 
 	// Get the send buffer
 	return m.rawSendMsgStream(conn, bufConn.Bytes(), streamLabel)
@@ -1091,7 +1091,7 @@ func (m *Memberlist) decryptRemoteState(bufConn io.Reader, streamLabel string) (
 	// Ensure we aren't asked to download too much. This is to guard against
 	// an attack vector where a huge amount of state is sent
 	moreBytes := binary.BigEndian.Uint32(cipherText.Bytes()[1:5])
-	metrics.AddSampleWithLabels([]string{"memberlist", "size", "remote"}, float32(moreBytes), m.metricLabels)
+	metrics.SetGaugeWithLabels([]string{"memberlist", "size", "remote"}, float32(moreBytes), m.metricLabels)
 
 	if moreBytes > maxPushStateBytes {
 		return nil, fmt.Errorf("Remote node state is larger than limit (%d)", moreBytes)

--- a/net.go
+++ b/net.go
@@ -87,13 +87,6 @@ const (
 	maxPushPullRequests    = 128 // Maximum number of concurrent push/pull requests
 )
 
-const (
-	nodeStateAlive   = "alive"
-	nodeStateDead    = "dead"
-	nodeStateLeft    = "left"
-	nodeStateSuspect = "suspect"
-)
-
 // ping request sent directly to node
 type ping struct {
 	SeqNo uint32
@@ -1015,22 +1008,13 @@ func (m *Memberlist) sendLocalState(conn net.Conn, join bool, streamLabel string
 	m.nodeLock.RUnlock()
 
 	nodeStateCounts := make(map[string]int)
-	nodeStateCounts[nodeStateAlive] = 0
-	nodeStateCounts[nodeStateLeft] = 0
-	nodeStateCounts[nodeStateDead] = 0
-	nodeStateCounts[nodeStateSuspect] = 0
+	nodeStateCounts[StateAlive.metricsString()] = 0
+	nodeStateCounts[StateLeft.metricsString()] = 0
+	nodeStateCounts[StateDead.metricsString()] = 0
+	nodeStateCounts[StateSuspect.metricsString()] = 0
 
 	for _, n := range localNodes {
-		switch n.State {
-		case StateAlive:
-			nodeStateCounts[nodeStateAlive]++
-		case StateDead:
-			nodeStateCounts[nodeStateDead]++
-		case StateSuspect:
-			nodeStateCounts[nodeStateSuspect]++
-		case StateLeft:
-			nodeStateCounts[nodeStateLeft]++
-		}
+		nodeStateCounts[n.State.metricsString()]++
 	}
 
 	for nodeState, cnt := range nodeStateCounts {

--- a/net.go
+++ b/net.go
@@ -1034,7 +1034,9 @@ func (m *Memberlist) sendLocalState(conn net.Conn, join bool, streamLabel string
 	}
 
 	for nodeState, cnt := range nodeStateCounts {
-		metrics.SetGaugeWithLabels([]string{"memberlist", "nodes", nodeState}, float32(cnt), m.metricLabels)
+		metrics.SetGaugeWithLabels([]string{"memberlist", "node", "instances"},
+			float32(cnt),
+			append(m.metricLabels, metrics.Label{Name: "node_state", Value: nodeState}))
 	}
 
 	// Get the delegate state

--- a/net.go
+++ b/net.go
@@ -1107,7 +1107,7 @@ func (m *Memberlist) decryptRemoteState(bufConn io.Reader, streamLabel string) (
 	// Ensure we aren't asked to download too much. This is to guard against
 	// an attack vector where a huge amount of state is sent
 	moreBytes := binary.BigEndian.Uint32(cipherText.Bytes()[1:5])
-	metrics.SetGaugeWithLabels([]string{"memberlist", "size", "remote"}, float32(moreBytes), m.metricLabels)
+	metrics.AddSampleWithLabels([]string{"memberlist", "size", "remote"}, float32(moreBytes), m.metricLabels)
 
 	if moreBytes > maxPushStateBytes {
 		return nil, fmt.Errorf("Remote node state is larger than limit (%d)", moreBytes)

--- a/net_test.go
+++ b/net_test.go
@@ -690,6 +690,7 @@ func TestEncryptDecryptState(t *testing.T) {
 		SecretKey:       []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
 		ProtocolVersion: ProtocolVersionMax,
 	}
+	sink := registerInMemorySink(t)
 
 	m, err := Create(config)
 	if err != nil {
@@ -710,6 +711,7 @@ func TestEncryptDecryptState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	verifySampleExists(t, "consul.usage.test.memberlist.size.remote", sink)
 
 	if !reflect.DeepEqual(state, plain) {
 		t.Fatalf("Decrypt failed: %v", plain)

--- a/net_test.go
+++ b/net_test.go
@@ -719,10 +719,10 @@ func TestEncryptDecryptState(t *testing.T) {
 
 	intv := getIntervalMetrics(t, sink)
 
-	sampleName := "consul.usage.test.memberlist.size.remote"
-	actualSample := intv.Samples[sampleName]
+	gaugeName := "consul.usage.test.memberlist.size.remote"
+	actualGauge := intv.Gauges[gaugeName]
 
-	if actualSample.Count == 0 {
+	if actualGauge.Value == 0 {
 		t.Fatalf("memberlist.size.remote sample not taken")
 	}
 }

--- a/net_test.go
+++ b/net_test.go
@@ -691,6 +691,8 @@ func TestEncryptDecryptState(t *testing.T) {
 		ProtocolVersion: ProtocolVersionMax,
 	}
 
+	sink := registerInMemorySink(t)
+
 	m, err := Create(config)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -713,6 +715,15 @@ func TestEncryptDecryptState(t *testing.T) {
 
 	if !reflect.DeepEqual(state, plain) {
 		t.Fatalf("Decrypt failed: %v", plain)
+	}
+
+	intv := getIntervalMetrics(t, sink)
+
+	sampleName := "consul.usage.test.memberlist.size.remote"
+	actualSample := intv.Samples[sampleName]
+
+	if actualSample.Count == 0 {
+		t.Fatalf("memberlist.size.remote sample not taken")
 	}
 }
 

--- a/net_test.go
+++ b/net_test.go
@@ -691,8 +691,6 @@ func TestEncryptDecryptState(t *testing.T) {
 		ProtocolVersion: ProtocolVersionMax,
 	}
 
-	sink := registerInMemorySink(t)
-
 	m, err := Create(config)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -715,15 +713,6 @@ func TestEncryptDecryptState(t *testing.T) {
 
 	if !reflect.DeepEqual(state, plain) {
 		t.Fatalf("Decrypt failed: %v", plain)
-	}
-
-	intv := getIntervalMetrics(t, sink)
-
-	gaugeName := "consul.usage.test.memberlist.size.remote"
-	actualGauge := intv.Gauges[gaugeName]
-
-	if actualGauge.Value == 0 {
-		t.Fatalf("memberlist.size.remote sample not taken")
 	}
 }
 

--- a/state.go
+++ b/state.go
@@ -15,6 +15,21 @@ import (
 
 type NodeStateType int
 
+func (t NodeStateType) metricsString() string {
+	switch t {
+	case StateAlive:
+		return "alive"
+	case StateDead:
+		return "dead"
+	case StateSuspect:
+		return "suspect"
+	case StateLeft:
+		return "left"
+	default:
+		return ""
+	}
+}
+
 const (
 	StateAlive NodeStateType = iota
 	StateSuspect

--- a/state.go
+++ b/state.go
@@ -26,7 +26,7 @@ func (t NodeStateType) metricsString() string {
 	case StateLeft:
 		return "left"
 	default:
-		return ""
+		return fmt.Sprintf("unhandled-value-%d", t)
 	}
 }
 

--- a/state_test.go
+++ b/state_test.go
@@ -2283,6 +2283,8 @@ func TestMemberlist_PushPull(t *testing.T) {
 	ip1 := []byte(addr1)
 	ip2 := []byte(addr2)
 
+	sink := registerInMemorySink(t)
+
 	ch := make(chan NodeEvent, 3)
 
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
@@ -2313,6 +2315,15 @@ func TestMemberlist_PushPull(t *testing.T) {
 
 		if len(ch) < 2 {
 			failf("expected 2 messages from pushPull")
+		}
+
+		intv := getIntervalMetrics(t, sink)
+
+		sampleName := "consul.usage.test.memberlist.size.local"
+		actualSample := intv.Samples[sampleName]
+
+		if actualSample.Count == 0 {
+			t.Fatalf("memberlist.size.local sample not taken")
 		}
 	})
 }

--- a/state_test.go
+++ b/state_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const healthScoreMetricGaugeName = "consul.usage.test.memberlist.health.score"
+
 func HostMemberlist(host string, t *testing.T, f func(*Config)) *Memberlist {
 	t.Helper()
 
@@ -559,6 +561,8 @@ func TestMemberList_ProbeNode_Awareness_Degraded(t *testing.T) {
 	ip3 := []byte(addr3)
 	ip4 := []byte(addr4)
 
+	sink := registerInMemorySink(t)
+
 	var probeTimeMin time.Duration
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
 		c.ProbeTimeout = 10 * time.Millisecond
@@ -604,6 +608,18 @@ func TestMemberList_ProbeNode_Awareness_Degraded(t *testing.T) {
 		t.Fatalf("bad: %d", score)
 	}
 
+	intv := getIntervalMetrics(t, sink)
+
+	expectedGauge := metrics.GaugeValue{
+		Name:  healthScoreMetricGaugeName,
+		Value: 1,
+	}
+	actualGauge := intv.Gauges[healthScoreMetricGaugeName]
+
+	if !reflect.DeepEqual(expectedGauge, actualGauge) {
+		t.Fatalf("gauges do not match")
+	}
+
 	// Have node m1 probe m4.
 	n := m1.nodeMap[addr4.String()]
 	startProbe := time.Now()
@@ -642,6 +658,8 @@ func TestMemberList_ProbeNode_Wrong_VSN(t *testing.T) {
 	ip2 := []byte(addr2)
 	ip3 := []byte(addr3)
 	ip4 := []byte(addr4)
+
+	sink := registerInMemorySink(t)
 
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
 		c.ProbeTimeout = 10 * time.Millisecond
@@ -686,6 +704,18 @@ func TestMemberList_ProbeNode_Wrong_VSN(t *testing.T) {
 		t.Fatalf("bad: %d", score)
 	}
 
+	intv := getIntervalMetrics(t, sink)
+
+	expectedGauge := metrics.GaugeValue{
+		Name:  healthScoreMetricGaugeName,
+		Value: 1,
+	}
+	actualGauge := intv.Gauges[healthScoreMetricGaugeName]
+
+	if !reflect.DeepEqual(expectedGauge, actualGauge) {
+		t.Fatalf("gauges do not match")
+	}
+
 	// Have node m1 probe m4.
 	n, ok := m1.nodeMap[addr4.String()]
 	if ok || n != nil {
@@ -698,6 +728,8 @@ func TestMemberList_ProbeNode_Awareness_Improved(t *testing.T) {
 	addr2 := getBindAddr()
 	ip1 := []byte(addr1)
 	ip2 := []byte(addr2)
+
+	sink := registerInMemorySink(t)
 
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
 		c.ProbeTimeout = 10 * time.Millisecond
@@ -721,6 +753,18 @@ func TestMemberList_ProbeNode_Awareness_Improved(t *testing.T) {
 	m1.awareness.ApplyDelta(1)
 	if score := m1.GetHealthScore(); score != 1 {
 		t.Fatalf("bad: %d", score)
+	}
+
+	intv := getIntervalMetrics(t, sink)
+
+	expectedGauge := metrics.GaugeValue{
+		Name:  healthScoreMetricGaugeName,
+		Value: 1,
+	}
+	actualGauge := intv.Gauges[healthScoreMetricGaugeName]
+
+	if !reflect.DeepEqual(expectedGauge, actualGauge) {
+		t.Fatalf("gauges do not match")
 	}
 
 	// Have node m1 probe m2.

--- a/state_test.go
+++ b/state_test.go
@@ -2274,12 +2274,11 @@ func TestMemberlist_PushPull(t *testing.T) {
 		}
 
 		instancesMetricName := "consul.usage.test.memberlist.node.instances"
-		verifyGaugesExists(t, []string{"consul.usage.test.memberlist.size.local",
-			fmt.Sprintf("%s;node_state=%s", instancesMetricName, nodeStateAlive),
-			fmt.Sprintf("%s;node_state=%s", instancesMetricName, nodeStateDead),
-			fmt.Sprintf("%s;node_state=%s", instancesMetricName, nodeStateLeft),
-			fmt.Sprintf("%s;node_state=%s", instancesMetricName, nodeStateSuspect)},
-			sink)
+		verifyGaugeExists(t, "consul.usage.test.memberlist.size.local", sink)
+		verifyGaugeExists(t, fmt.Sprintf("%s;node_state=%s", instancesMetricName, nodeStateAlive), sink)
+		verifyGaugeExists(t, fmt.Sprintf("%s;node_state=%s", instancesMetricName, nodeStateDead), sink)
+		verifyGaugeExists(t, fmt.Sprintf("%s;node_state=%s", instancesMetricName, nodeStateLeft), sink)
+		verifyGaugeExists(t, fmt.Sprintf("%s;node_state=%s", instancesMetricName, nodeStateSuspect), sink)
 	})
 }
 
@@ -2423,24 +2422,21 @@ func getIntervalMetrics(t *testing.T, sink *metrics.InmemSink) *metrics.Interval
 	return intv
 }
 
-func verifyGaugesExists(t *testing.T, names []string, sink *metrics.InmemSink) {
+func verifyGaugeExists(t *testing.T, name string, sink *metrics.InmemSink) {
 	interval := getIntervalMetrics(t, sink)
 	interval.RLock()
 	defer interval.RUnlock()
-	for _, name := range names {
-		if _, ok := interval.Gauges[name]; !ok {
-			t.Fatalf("%s gauge not emmited", name)
-		}
+	if _, ok := interval.Gauges[name]; !ok {
+		t.Fatalf("%s gauge not emmited", name)
 	}
 }
 
-func verifySamplesExists(t *testing.T, names []string, sink *metrics.InmemSink) {
+func verifySampleExists(t *testing.T, name string, sink *metrics.InmemSink) {
 	interval := getIntervalMetrics(t, sink)
 	interval.RLock()
 	defer interval.RUnlock()
-	for _, name := range names {
-		if _, ok := interval.Samples[name]; !ok {
-			t.Fatalf("%s sample not emmited", name)
-		}
+
+	if _, ok := interval.Samples[name]; !ok {
+		t.Fatalf("%s sample not emmited", name)
 	}
 }

--- a/state_test.go
+++ b/state_test.go
@@ -2273,11 +2273,13 @@ func TestMemberlist_PushPull(t *testing.T) {
 			failf("expected 2 messages from pushPull")
 		}
 
-		verifyGaugeExists(t, "consul.usage.test.memberlist.size.local", sink)
-		verifyGaugeExists(t, "consul.usage.test.memberlist.nodes.alive", sink)
-		verifyGaugeExists(t, "consul.usage.test.memberlist.nodes.suspect", sink)
-		verifyGaugeExists(t, "consul.usage.test.memberlist.nodes.left", sink)
-		verifyGaugeExists(t, "consul.usage.test.memberlist.nodes.dead", sink)
+		instancesMetricName := "consul.usage.test.memberlist.node.instances"
+		verifyGaugesExists(t, []string{"consul.usage.test.memberlist.size.local",
+			fmt.Sprintf("%s;node_state=%s", instancesMetricName, nodeStateAlive),
+			fmt.Sprintf("%s;node_state=%s", instancesMetricName, nodeStateDead),
+			fmt.Sprintf("%s;node_state=%s", instancesMetricName, nodeStateLeft),
+			fmt.Sprintf("%s;node_state=%s", instancesMetricName, nodeStateSuspect)},
+			sink)
 	})
 }
 
@@ -2421,20 +2423,24 @@ func getIntervalMetrics(t *testing.T, sink *metrics.InmemSink) *metrics.Interval
 	return intv
 }
 
-func verifyGaugeExists(t *testing.T, name string, sink *metrics.InmemSink) {
+func verifyGaugesExists(t *testing.T, names []string, sink *metrics.InmemSink) {
 	interval := getIntervalMetrics(t, sink)
 	interval.RLock()
 	defer interval.RUnlock()
-	if _, ok := interval.Gauges[name]; !ok {
-		t.Fatalf("%s gauge not emmited", name)
+	for _, name := range names {
+		if _, ok := interval.Gauges[name]; !ok {
+			t.Fatalf("%s gauge not emmited", name)
+		}
 	}
 }
 
-func verifySampleExists(t *testing.T, name string, sink *metrics.InmemSink) {
+func verifySamplesExists(t *testing.T, names []string, sink *metrics.InmemSink) {
 	interval := getIntervalMetrics(t, sink)
 	interval.RLock()
 	defer interval.RUnlock()
-	if _, ok := interval.Samples[name]; !ok {
-		t.Fatalf("%s sample not emmited", name)
+	for _, name := range names {
+		if _, ok := interval.Samples[name]; !ok {
+			t.Fatalf("%s sample not emmited", name)
+		}
 	}
 }

--- a/state_test.go
+++ b/state_test.go
@@ -2317,14 +2317,11 @@ func TestMemberlist_PushPull(t *testing.T) {
 			failf("expected 2 messages from pushPull")
 		}
 
-		intv := getIntervalMetrics(t, sink)
-
-		gaugeName := "consul.usage.test.memberlist.size.local"
-		actualGauge := intv.Gauges[gaugeName]
-
-		if actualGauge.Value == 0 {
-			t.Fatalf("memberlist.size.local gauge not emitted")
-		}
+		verifyGaugeExists(t, "consul.usage.test.memberlist.size.local", sink)
+		verifyGaugeExists(t, "consul.usage.test.memberlist.nodes.alive", sink)
+		verifyGaugeExists(t, "consul.usage.test.memberlist.nodes.suspect", sink)
+		verifyGaugeExists(t, "consul.usage.test.memberlist.nodes.left", sink)
+		verifyGaugeExists(t, "consul.usage.test.memberlist.nodes.dead", sink)
 	})
 }
 
@@ -2466,4 +2463,11 @@ func getIntervalMetrics(t *testing.T, sink *metrics.InmemSink) *metrics.Interval
 	require.Len(t, intervals, 1)
 	intv := intervals[0]
 	return intv
+}
+
+func verifyGaugeExists(t *testing.T, name string, sink *metrics.InmemSink) {
+	interval := getIntervalMetrics(t, sink)
+	if _, ok := interval.Gauges[name]; !ok {
+		t.Fatalf("%s gauge not emmited", name)
+	}
 }

--- a/state_test.go
+++ b/state_test.go
@@ -2275,10 +2275,10 @@ func TestMemberlist_PushPull(t *testing.T) {
 
 		instancesMetricName := "consul.usage.test.memberlist.node.instances"
 		verifyGaugeExists(t, "consul.usage.test.memberlist.size.local", sink)
-		verifyGaugeExists(t, fmt.Sprintf("%s;node_state=%s", instancesMetricName, nodeStateAlive), sink)
-		verifyGaugeExists(t, fmt.Sprintf("%s;node_state=%s", instancesMetricName, nodeStateDead), sink)
-		verifyGaugeExists(t, fmt.Sprintf("%s;node_state=%s", instancesMetricName, nodeStateLeft), sink)
-		verifyGaugeExists(t, fmt.Sprintf("%s;node_state=%s", instancesMetricName, nodeStateSuspect), sink)
+		verifyGaugeExists(t, fmt.Sprintf("%s;node_state=%s", instancesMetricName, StateAlive.metricsString()), sink)
+		verifyGaugeExists(t, fmt.Sprintf("%s;node_state=%s", instancesMetricName, StateDead.metricsString()), sink)
+		verifyGaugeExists(t, fmt.Sprintf("%s;node_state=%s", instancesMetricName, StateLeft.metricsString()), sink)
+		verifyGaugeExists(t, fmt.Sprintf("%s;node_state=%s", instancesMetricName, StateSuspect.metricsString()), sink)
 	})
 }
 

--- a/state_test.go
+++ b/state_test.go
@@ -2319,11 +2319,11 @@ func TestMemberlist_PushPull(t *testing.T) {
 
 		intv := getIntervalMetrics(t, sink)
 
-		sampleName := "consul.usage.test.memberlist.size.local"
-		actualSample := intv.Samples[sampleName]
+		gaugeName := "consul.usage.test.memberlist.size.local"
+		actualGauge := intv.Gauges[gaugeName]
 
-		if actualSample.Count == 0 {
-			t.Fatalf("memberlist.size.local sample not taken")
+		if actualGauge.Value == 0 {
+			t.Fatalf("memberlist.size.local gauge not emitted")
 		}
 	})
 }

--- a/state_test.go
+++ b/state_test.go
@@ -2423,7 +2423,18 @@ func getIntervalMetrics(t *testing.T, sink *metrics.InmemSink) *metrics.Interval
 
 func verifyGaugeExists(t *testing.T, name string, sink *metrics.InmemSink) {
 	interval := getIntervalMetrics(t, sink)
+	interval.RLock()
+	defer interval.RUnlock()
 	if _, ok := interval.Gauges[name]; !ok {
 		t.Fatalf("%s gauge not emmited", name)
+	}
+}
+
+func verifySampleExists(t *testing.T, name string, sink *metrics.InmemSink) {
+	interval := getIntervalMetrics(t, sink)
+	interval.RLock()
+	defer interval.RUnlock()
+	if _, ok := interval.Samples[name]; !ok {
+		t.Fatalf("%s sample not emmited", name)
 	}
 }

--- a/state_test.go
+++ b/state_test.go
@@ -2423,6 +2423,7 @@ func getIntervalMetrics(t *testing.T, sink *metrics.InmemSink) *metrics.Interval
 }
 
 func verifyGaugeExists(t *testing.T, name string, sink *metrics.InmemSink) {
+	t.Helper()
 	interval := getIntervalMetrics(t, sink)
 	interval.RLock()
 	defer interval.RUnlock()
@@ -2432,6 +2433,7 @@ func verifyGaugeExists(t *testing.T, name string, sink *metrics.InmemSink) {
 }
 
 func verifySampleExists(t *testing.T, name string, sink *metrics.InmemSink) {
+	t.Helper()
 	interval := getIntervalMetrics(t, sink)
 	interval.RLock()
 	defer interval.RUnlock()

--- a/state_test.go
+++ b/state_test.go
@@ -18,8 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const healthScoreMetricGaugeName = "consul.usage.test.memberlist.health.score"
-
 func HostMemberlist(host string, t *testing.T, f func(*Config)) *Memberlist {
 	t.Helper()
 
@@ -561,8 +559,6 @@ func TestMemberList_ProbeNode_Awareness_Degraded(t *testing.T) {
 	ip3 := []byte(addr3)
 	ip4 := []byte(addr4)
 
-	sink := registerInMemorySink(t)
-
 	var probeTimeMin time.Duration
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
 		c.ProbeTimeout = 10 * time.Millisecond
@@ -608,18 +604,6 @@ func TestMemberList_ProbeNode_Awareness_Degraded(t *testing.T) {
 		t.Fatalf("bad: %d", score)
 	}
 
-	intv := getIntervalMetrics(t, sink)
-
-	expectedGauge := metrics.GaugeValue{
-		Name:  healthScoreMetricGaugeName,
-		Value: 1,
-	}
-	actualGauge := intv.Gauges[healthScoreMetricGaugeName]
-
-	if !reflect.DeepEqual(expectedGauge, actualGauge) {
-		t.Fatalf("gauges do not match")
-	}
-
 	// Have node m1 probe m4.
 	n := m1.nodeMap[addr4.String()]
 	startProbe := time.Now()
@@ -658,8 +642,6 @@ func TestMemberList_ProbeNode_Wrong_VSN(t *testing.T) {
 	ip2 := []byte(addr2)
 	ip3 := []byte(addr3)
 	ip4 := []byte(addr4)
-
-	sink := registerInMemorySink(t)
 
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
 		c.ProbeTimeout = 10 * time.Millisecond
@@ -704,18 +686,6 @@ func TestMemberList_ProbeNode_Wrong_VSN(t *testing.T) {
 		t.Fatalf("bad: %d", score)
 	}
 
-	intv := getIntervalMetrics(t, sink)
-
-	expectedGauge := metrics.GaugeValue{
-		Name:  healthScoreMetricGaugeName,
-		Value: 1,
-	}
-	actualGauge := intv.Gauges[healthScoreMetricGaugeName]
-
-	if !reflect.DeepEqual(expectedGauge, actualGauge) {
-		t.Fatalf("gauges do not match")
-	}
-
 	// Have node m1 probe m4.
 	n, ok := m1.nodeMap[addr4.String()]
 	if ok || n != nil {
@@ -728,8 +698,6 @@ func TestMemberList_ProbeNode_Awareness_Improved(t *testing.T) {
 	addr2 := getBindAddr()
 	ip1 := []byte(addr1)
 	ip2 := []byte(addr2)
-
-	sink := registerInMemorySink(t)
 
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
 		c.ProbeTimeout = 10 * time.Millisecond
@@ -753,18 +721,6 @@ func TestMemberList_ProbeNode_Awareness_Improved(t *testing.T) {
 	m1.awareness.ApplyDelta(1)
 	if score := m1.GetHealthScore(); score != 1 {
 		t.Fatalf("bad: %d", score)
-	}
-
-	intv := getIntervalMetrics(t, sink)
-
-	expectedGauge := metrics.GaugeValue{
-		Name:  healthScoreMetricGaugeName,
-		Value: 1,
-	}
-	actualGauge := intv.Gauges[healthScoreMetricGaugeName]
-
-	if !reflect.DeepEqual(expectedGauge, actualGauge) {
-		t.Fatalf("gauges do not match")
 	}
 
 	// Have node m1 probe m2.


### PR DESCRIPTION
## Changes proposed
- emit a `"memberlist", "node", "instances"` Gauge and pass label so a gauge can be broken out by node state
  - it appears gauges are reported with the host/pod name in the metric.  so the above gauge will emit metrics in the sink (grafana) for 1 server and 3 clients as:
    - consul_server_0_memberlist_node_instances
    - consul_client_1_memberlist_node_instances
    - consul_client_2_memberlist_node_instances
    - consul_client_3_memberlist_node_instances
 
<img width="450" alt="Screen Shot 2022-08-30 at 11 53 49 AM" src="https://user-images.githubusercontent.com/2481360/187511371-ec9b6bbb-4e7a-4f59-963e-bc75dcb19fe7.png">

<img width="460" alt="Screen Shot 2022-08-30 at 11 53 26 AM" src="https://user-images.githubusercontent.com/2481360/187511070-f8d66f16-2061-4723-a63b-6d905424a2ed.png">

- emit `"memberlist", "size", "local"` Gauge that reports the size in bytes of the memberlist size before it is sent to another gossip recipient.
  - same condition as above for multiple metrics being create by hostname

<img width="450" alt="Screen Shot 2022-08-30 at 11 56 46 AM" src="https://user-images.githubusercontent.com/2481360/187511234-bbaab80a-f5a4-46b5-a907-7463006d801f.png">
- emit `"memberlist", "size", "remote"` Gauge that reports the size of incoming memberlists from other gossip senders
  - is this helpful?  I feel like we would have to add a label for who is sending it?
