### PR TITLE
[DO-NOT-MERGE] Ensure messages in gossip function are the same for each node

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -74,9 +74,9 @@ func (m *Memberlist) queueBroadcast(node string, msg []byte, notify chan struct{
 // getBroadcasts is used to return a slice of broadcasts to send up to
 // a maximum byte size, while imposing a per-broadcast overhead. This is used
 // to fill a UDP packet with piggybacked data
-func (m *Memberlist) getBroadcasts(overhead, limit int) [][]byte {
+func (m *Memberlist) getBroadcasts(overhead, limit, transmissionCount int) [][]byte {
 	// Get memberlist messages first
-	toSend := m.broadcasts.GetBroadcasts(overhead, limit)
+	toSend := m.broadcasts.GetBroadcasts(overhead, limit, transmissionCount)
 
 	// Check if the user has anything to broadcast
 	d := m.config.Delegate

--- a/net.go
+++ b/net.go
@@ -788,7 +788,7 @@ func (m *Memberlist) sendMsg(a Address, msg []byte) error {
 	if m.config.EncryptionEnabled() && m.config.GossipVerifyOutgoing {
 		bytesAvail -= encryptOverhead(m.encryptionVersion())
 	}
-	extra := m.getBroadcasts(compoundOverhead, bytesAvail)
+	extra := m.getBroadcasts(compoundOverhead, bytesAvail, 1)
 
 	// Fast path if nothing to piggypack
 	if len(extra) == 0 {

--- a/queue.go
+++ b/queue.go
@@ -320,7 +320,7 @@ func (q *TransmitLimitedQueue) GetBroadcasts(overhead, limit, transmissionCount 
 			id:        math.MaxInt64,
 		}
 		lessThan := &limitedBroadcast{
-			transmits: transmits + 1,
+			transmits: transmits + transmissionCount,
 			msgLen:    math.MaxInt64,
 			id:        math.MaxInt64,
 		}

--- a/queue_test.go
+++ b/queue_test.go
@@ -102,11 +102,11 @@ func TestTransmitLimited_GetBroadcasts(t *testing.T) {
 	q.QueueBroadcast(&memberlistBroadcast{"baz", []byte("4. this is a test."), nil})
 
 	// 2 byte overhead per message, should get all 4 messages
-	all := q.GetBroadcasts(2, 80)
+	all := q.GetBroadcasts(2, 80, 1)
 	require.Equal(t, 4, len(all), "missing messages: %v", prettyPrintMessages(all))
 
 	// 3 byte overhead, should only get 3 messages back
-	partial := q.GetBroadcasts(3, 80)
+	partial := q.GetBroadcasts(3, 80, 1)
 	require.Equal(t, 3, len(partial), "missing messages: %v", prettyPrintMessages(partial))
 }
 
@@ -125,24 +125,24 @@ func TestTransmitLimited_GetBroadcasts_Limit(t *testing.T) {
 	require.Equal(t, int64(4), q.idGen, "we handed out 4 IDs")
 
 	// 3 byte overhead, should only get 3 messages back
-	partial1 := q.GetBroadcasts(3, 80)
+	partial1 := q.GetBroadcasts(3, 80, 1)
 	require.Equal(t, 3, len(partial1), "missing messages: %v", prettyPrintMessages(partial1))
 
 	require.Equal(t, int64(4), q.idGen, "id generator doesn't reset until empty")
 
-	partial2 := q.GetBroadcasts(3, 80)
+	partial2 := q.GetBroadcasts(3, 80, 1)
 	require.Equal(t, 3, len(partial2), "missing messages: %v", prettyPrintMessages(partial2))
 
 	require.Equal(t, int64(4), q.idGen, "id generator doesn't reset until empty")
 
 	// Only two not expired
-	partial3 := q.GetBroadcasts(3, 80)
+	partial3 := q.GetBroadcasts(3, 80, 1)
 	require.Equal(t, 2, len(partial3), "missing messages: %v", prettyPrintMessages(partial3))
 
 	require.Equal(t, int64(0), q.idGen, "id generator resets on empty")
 
 	// Should get nothing
-	partial5 := q.GetBroadcasts(3, 80)
+	partial5 := q.GetBroadcasts(3, 80, 1)
 	require.Equal(t, 0, len(partial5), "missing messages: %v", prettyPrintMessages(partial5))
 
 	require.Equal(t, int64(0), q.idGen, "id generator resets on empty")

--- a/state.go
+++ b/state.go
@@ -622,7 +622,6 @@ func (m *Memberlist) gossip() {
 	} else if len(msgs) == 1 {
 		// Send single message as is to each node.
 		for _, node := range kNodes {
-			// Get any pending broadcasts
 			m.rawSendMsgPacketToNode(node, msgs[0])
 		}
 	} else {

--- a/state.go
+++ b/state.go
@@ -616,13 +616,12 @@ func (m *Memberlist) gossip() {
 		bytesAvail -= encryptOverhead(m.encryptionVersion())
 	}
 
+	msgs := m.getBroadcasts(compoundOverhead, bytesAvail)
+	if len(msgs) == 0 {
+		return
+	}
 	for _, node := range kNodes {
 		// Get any pending broadcasts
-		msgs := m.getBroadcasts(compoundOverhead, bytesAvail)
-		if len(msgs) == 0 {
-			return
-		}
-
 		addr := node.Address()
 		if len(msgs) == 1 {
 			// Send single message as is

--- a/state.go
+++ b/state.go
@@ -616,7 +616,7 @@ func (m *Memberlist) gossip() {
 		bytesAvail -= encryptOverhead(m.encryptionVersion())
 	}
 
-	msgs := m.getBroadcasts(compoundOverhead, bytesAvail)
+	msgs := m.getBroadcasts(compoundOverhead, bytesAvail, len(kNodes))
 	if len(msgs) == 0 {
 		return
 	} else if len(msgs) == 1 {


### PR DESCRIPTION
This refactor addresses:
- removing the getBroadcasts() call out of the message/node loop so that we avoid the potential case that one node gets a different set of messages than another. (and therefore infection rate is diminished because for a given message because not all 3 nodes are relaying it).
- making sure that compound messages are not rebuilt for each node and we ensure they each get the same compound messages (and also less processing).