### PR TITLE
remove circleci badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# memberlist [![GoDoc](https://godoc.org/github.com/hashicorp/memberlist?status.png)](https://godoc.org/github.com/hashicorp/memberlist) [![CircleCI](https://circleci.com/gh/hashicorp/memberlist.svg?style=svg)](https://circleci.com/gh/hashicorp/memberlist)
-
+# memberlist [![GoDoc](https://godoc.org/github.com/hashicorp/memberlist?status.png)](https://godoc.org/github.com/hashicorp/memberlist)
 memberlist is a [Go](http://www.golang.org) library that manages cluster
 membership and member failure detection using a gossip based protocol.
 


### PR DESCRIPTION
it seems that the circleci isn't used anymore for the project, since the last circleci build is red, and it is from 1 year ago. There is also no config.yaml in the repo