### PR TITLE
fix node state export

### DIFF
--- a/memberlist.go
+++ b/memberlist.go
@@ -611,6 +611,7 @@ func (m *Memberlist) Members() []*Node {
 	nodes := make([]*Node, 0, len(m.nodes))
 	for _, n := range m.nodes {
 		if !n.DeadOrLeft() {
+			n.Node.State = n.State
 			nodes = append(nodes, &n.Node)
 		}
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -255,13 +255,14 @@ func TestKRandomNodes(t *testing.T) {
 		nodes = append(nodes, &nodeState{
 			Node: Node{
 				Name: fmt.Sprintf("test%d", i),
+				State: state,
 			},
 			State: state,
 		})
 	}
 
 	filterFunc := func(n *nodeState) bool {
-		if n.Name == "test0" || n.State != StateAlive {
+		if n.Name == "test0" || n.Node.State != StateAlive {
 			return true
 		}
 		return false


### PR DESCRIPTION
This commit fix the https://github.com/hashicorp/memberlist/issues/266 that get the confusion state of node when Members called, due to c192837f commit which involved two state varibale for one node.