### PR TITLE
reduce number of addresses in loopback

### DIFF
--- a/test/setup_subnet.sh
+++ b/test/setup_subnet.sh
@@ -29,10 +29,21 @@ case $OSTYPE in
         ;;
 esac
 
-# Setup loopback
-for j in 0 1 2
+# first loopback, use intensively
+for ((i=10;i<256;i++))
+  do
+      if [ "$action" = "up" ]
+      then
+        sudo ifconfig lo0 alias 127.0.0.$i up
+      else
+        sudo ifconfig lo0 127.0.0.$i delete
+     fi
+  done
+
+# Not use much, only need a few
+for j in 1 2
 do
-  for ((i=2;i<256;i++))
+  for ((i=10;i<15;i++))
   do
       if [ "$action" = "up" ]
       then
@@ -42,3 +53,4 @@ do
      fi
   done
 done
+


### PR DESCRIPTION
the address in 127.0.1.0/24 and 127.0.2.0/24 are needed for TestMemberlist_JoinDifferentNetworksMultiMasks and TestMemberlist_JoinDifferentNetworksUniqueMask. Only a few addresses are needed in these tests. Creating too many addresses in loopback may cause unexpected problems on network stack of local machine. For example, git can not resolve github.com on my laptop!