### PR TITLE
remove leavelock

### DIFF
--- a/memberlist.go
+++ b/memberlist.go
@@ -55,7 +55,6 @@ type Memberlist struct {
 	leaveBroadcast chan struct{}
 
 	shutdownLock sync.Mutex // Serializes calls to Shutdown
-	leaveLock    sync.Mutex // Serializes calls to Leave
 
 	transport NodeAwareTransport
 
@@ -646,8 +645,6 @@ func (m *Memberlist) NumMembers() (alive int) {
 // This method is safe to call multiple times, but must not be called
 // after the cluster is already shut down.
 func (m *Memberlist) Leave(timeout time.Duration) error {
-	m.leaveLock.Lock()
-	defer m.leaveLock.Unlock()
 
 	if m.hasShutdown() {
 		panic("leave after shutdown")


### PR DESCRIPTION
as m.leave is atomic, there's no need to guard against concurrent access to m.Leave(). a check of m.hasLeft will reject the later calls to m.Leave once m.leave was set atomically.