### PR TITLE
Export node State to NotifyLeave callback

### DIFF
--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -613,17 +613,15 @@ func TestMemberList_ResolveAddr_TCP_First(t *testing.T) {
 }
 
 func TestMemberList_Members(t *testing.T) {
-	n1 := &Node{Name: "test"}
-	n2 := &Node{Name: "test2"}
-	n3 := &Node{Name: "test3"}
+	n1 := &Node{Name: "test", State: StateAlive}
+	n2 := &Node{Name: "test2", State: StateDead}
+	n3 := &Node{Name: "test3", State: StateSuspect}
 
-	m := &Memberlist{}
-	nodes := []*nodeState{
-		&nodeState{Node: *n1, State: StateAlive},
-		&nodeState{Node: *n2, State: StateDead},
-		&nodeState{Node: *n3, State: StateSuspect},
-	}
-	m.nodes = nodes
+	m := &Memberlist{nodes: []*nodeState{
+		{Node: *n1},
+		{Node: *n2},
+		{Node: *n3},
+	}}
 
 	members := m.Members()
 	if !reflect.DeepEqual(members, []*Node{n1, n3}) {

--- a/net_test.go
+++ b/net_test.go
@@ -472,12 +472,12 @@ func TestTCPPushPull(t *testing.T) {
 
 	m.nodes = append(m.nodes, &nodeState{
 		Node: Node{
-			Name: "Test 0",
-			Addr: net.ParseIP(m.config.BindAddr),
-			Port: uint16(m.config.BindPort),
+			Name:  "Test 0",
+			Addr:  net.ParseIP(m.config.BindAddr),
+			Port:  uint16(m.config.BindPort),
+			State: StateSuspect,
 		},
 		Incarnation: 0,
-		State:       StateSuspect,
 		StateChange: time.Now().Add(-1 * time.Second),
 	})
 

--- a/state.go
+++ b/state.go
@@ -78,9 +78,8 @@ func (n *Node) String() string {
 // NodeState is used to manage our state view of another node
 type nodeState struct {
 	Node
-	Incarnation uint32        // Last known incarnation number
-	State       NodeStateType // Current state
-	StateChange time.Time     // Time last state change happened
+	Incarnation uint32    // Last known incarnation number
+	StateChange time.Time // Time last state change happened
 }
 
 // Address returns the host:port form of a node's address, suitable for use
@@ -1006,12 +1005,12 @@ func (m *Memberlist) aliveNode(a *alive, notify chan struct{}, bootstrap bool) {
 		}
 		state = &nodeState{
 			Node: Node{
-				Name: a.Node,
-				Addr: a.Addr,
-				Port: a.Port,
-				Meta: a.Meta,
+				Name:  a.Node,
+				Addr:  a.Addr,
+				Port:  a.Port,
+				Meta:  a.Meta,
+				State: StateDead,
 			},
-			State: StateDead,
 		}
 		if len(a.Vsn) > 5 {
 			state.PMin = a.Vsn[0]

--- a/util_test.go
+++ b/util_test.go
@@ -108,28 +108,28 @@ func TestRetransmitLimit(t *testing.T) {
 func TestShuffleNodes(t *testing.T) {
 	orig := []*nodeState{
 		&nodeState{
-			State: StateDead,
+			Node: Node{State: StateDead},
 		},
 		&nodeState{
-			State: StateAlive,
+			Node: Node{State: StateAlive},
 		},
 		&nodeState{
-			State: StateAlive,
+			Node: Node{State: StateAlive},
 		},
 		&nodeState{
-			State: StateDead,
+			Node: Node{State: StateDead},
 		},
 		&nodeState{
-			State: StateAlive,
+			Node: Node{State: StateAlive},
 		},
 		&nodeState{
-			State: StateAlive,
+			Node: Node{State: StateAlive},
 		},
 		&nodeState{
-			State: StateDead,
+			Node: Node{State: StateDead},
 		},
 		&nodeState{
-			State: StateAlive,
+			Node: Node{State: StateAlive},
 		},
 	}
 	nodes := make([]*nodeState, len(orig))
@@ -168,43 +168,43 @@ func TestPushPullScale(t *testing.T) {
 func TestMoveDeadNodes(t *testing.T) {
 	nodes := []*nodeState{
 		&nodeState{
-			State:       StateDead,
+			Node:        Node{State: StateDead},
 			StateChange: time.Now().Add(-20 * time.Second),
 		},
 		&nodeState{
-			State:       StateAlive,
+			Node:        Node{State: StateAlive},
 			StateChange: time.Now().Add(-20 * time.Second),
 		},
 		// This dead node should not be moved, as its state changed
 		// less than the specified GossipToTheDead time ago
 		&nodeState{
-			State:       StateDead,
+			Node:        Node{State: StateDead},
 			StateChange: time.Now().Add(-10 * time.Second),
 		},
 		// This left node should not be moved, as its state changed
 		// less than the specified GossipToTheDead time ago
 		&nodeState{
-			State:       StateLeft,
+			Node:        Node{State: StateLeft},
 			StateChange: time.Now().Add(-10 * time.Second),
 		},
 		&nodeState{
-			State:       StateLeft,
+			Node:        Node{State: StateLeft},
 			StateChange: time.Now().Add(-20 * time.Second),
 		},
 		&nodeState{
-			State:       StateAlive,
+			Node:        Node{State: StateAlive},
 			StateChange: time.Now().Add(-20 * time.Second),
 		},
 		&nodeState{
-			State:       StateDead,
+			Node:        Node{State: StateDead},
 			StateChange: time.Now().Add(-20 * time.Second),
 		},
 		&nodeState{
-			State:       StateAlive,
+			Node:        Node{State: StateAlive},
 			StateChange: time.Now().Add(-20 * time.Second),
 		},
 		&nodeState{
-			State:       StateLeft,
+			Node:        Node{State: StateLeft},
 			StateChange: time.Now().Add(-20 * time.Second),
 		},
 	}
@@ -254,9 +254,9 @@ func TestKRandomNodes(t *testing.T) {
 		}
 		nodes = append(nodes, &nodeState{
 			Node: Node{
-				Name: fmt.Sprintf("test%d", i),
+				Name:  fmt.Sprintf("test%d", i),
+				State: state,
 			},
-			State: state,
 		})
 	}
 


### PR DESCRIPTION
The node State was exported to the application in #223, but only the MergeDelegate is passed Node values with the State field initialized. The actual state of each node as tracked by the local memberlist is hidden from the application in the non-exported nodeState struct which embeds Node. Remove the State field from nodeState so that the State field on the embedded Node is instead used to track the node state. This has the effect of making the actual state of the node (Left vs. Dead) available to NotifyLeave callbacks as a pointer to the nodeState's embedded Node struct is passed to EventDelegate callbacks.

Fixes #266
Fixes #293
Closes #298 