### PR TITLE
testing: reduce test flakiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@ _cgo_gotypes.go
 _cgo_export.*
 
 _testmain.go
+coverage.out
 
 *.exe
 *.test
 .vagrant/
-

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SHELL := /bin/bash
 
 # test runs the test suite
 test: subnet
-	go test ./...
+	go test -count ./...
 
 # runs integration tests
 integ: subnet
@@ -16,7 +16,7 @@ integ: subnet
 # subnet sets up the require subnet for testing on darwin (osx) - you must run
 # this before running other tests if you are on osx.
 subnet:
-	@sh -c "'$(CURDIR)/scripts/setup_test_subnet.sh'"
+	@sh -c "'$(CURDIR)/test/setup_subnet.sh'"
 
 # cov runs tests with a coverage profile
 cov:
@@ -24,8 +24,8 @@ cov:
 	go tool cover -html=coverage.out
 
 # testrace runs the race checker
-testrace: subnet vet
-	go test -race ./... $(TESTARGS)
+testrace: subnet
+	go test -count=1 -race ./... $(TESTARGS)
 
 # check runs all the linters and custom checks
 check: lint tidy copywriteheaders

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -19,7 +19,6 @@ import (
 
 	iretry "github.com/hashicorp/memberlist/internal/retry"
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -568,7 +567,9 @@ func (h dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 }
 
 func TestMemberList_ResolveAddr_TCP_First(t *testing.T) {
-	bind := "127.0.0.1:8600"
+	// Use unique IP address and dynamic port allocation
+	bindIP := getBindAddr()
+	bind := net.JoinHostPort(bindIP.String(), "0")
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -591,6 +592,9 @@ func TestMemberList_ResolveAddr_TCP_First(t *testing.T) {
 	}()
 	wg.Wait()
 
+	// Get the actual bind address after server starts
+	actualBind := server.Listener.Addr().String()
+
 	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -601,7 +605,7 @@ func TestMemberList_ResolveAddr_TCP_First(t *testing.T) {
 		}
 	}()
 
-	content := fmt.Appendf(nil, "nameserver %s", bind)
+	content := fmt.Appendf(nil, "nameserver %s", actualBind)
 	if _, err := tmpFile.Write(content); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -742,19 +746,14 @@ func testMemberlist_Join_with_Labels(t *testing.T, secretKey []byte) {
 		}
 	}()
 
-	checkHost := func(t *testing.T, m *Memberlist, expected int) {
-		assert.Equal(t, expected, len(m.Members()))
-		assert.Equal(t, expected, m.estNumNodes())
-	}
-
 	runStep(t, "same label can join", func(t *testing.T) {
 		num, err := m2.Join([]string{m1.config.Name + "/" + m1.config.BindAddr})
 		require.NoError(t, err)
 		require.Equal(t, 1, num)
 
-		// Check the hosts
-		checkHost(t, m2, 2)
-		checkHost(t, m1, 2)
+		// Wait for cluster convergence (both members and estimate)
+		waitUntilSizeAndEstimate(t, m2, 2)
+		waitUntilSizeAndEstimate(t, m1, 2)
 	})
 
 	// Create a third node that uses no label
@@ -773,11 +772,10 @@ func testMemberlist_Join_with_Labels(t *testing.T, secretKey []byte) {
 		_, err := m3.Join([]string{m1.config.Name + "/" + m1.config.BindAddr})
 		require.Error(t, err)
 
-		// Check the failed host
-		checkHost(t, m3, 1)
-		// Check the existing hosts
-		checkHost(t, m2, 2)
-		checkHost(t, m1, 2)
+		// Verify cluster state remains unchanged after failed join
+		waitUntilSizeAndEstimate(t, m3, 1)
+		waitUntilSizeAndEstimate(t, m2, 2)
+		waitUntilSizeAndEstimate(t, m1, 2)
 	})
 
 	// Create a fourth node that uses a mismatched label
@@ -797,13 +795,11 @@ func testMemberlist_Join_with_Labels(t *testing.T, secretKey []byte) {
 		_, err := m4.Join([]string{m1.config.Name + "/" + m1.config.BindAddr})
 		require.Error(t, err)
 
-		// Check the failed host
-		checkHost(t, m4, 1)
-		// Check the previous failed host
-		checkHost(t, m3, 1)
-		// Check the existing hosts
-		checkHost(t, m2, 2)
-		checkHost(t, m1, 2)
+		// Verify cluster state remains unchanged after failed join
+		waitUntilSizeAndEstimate(t, m4, 1)
+		waitUntilSizeAndEstimate(t, m3, 1)
+		waitUntilSizeAndEstimate(t, m2, 2)
+		waitUntilSizeAndEstimate(t, m1, 2)
 	})
 }
 
@@ -1699,15 +1695,9 @@ func TestMemberlist_Join_Protocol_Compatibility(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, num)
 
-		// Check the hosts
-		if len(m2.Members()) != 2 {
-			t.Fatalf("should have 2 nodes! %v", m2.Members())
-		}
-
-		// Check the hosts
-		if len(m1.Members()) != 2 {
-			t.Fatalf("should have 2 nodes! %v", m1.Members())
-		}
+		// Wait for cluster convergence
+		waitUntilSize(t, m2, 2)
+		waitUntilSize(t, m1, 2)
 	}
 
 	t.Run("2,1", func(t *testing.T) {
@@ -2030,6 +2020,22 @@ func waitUntilSize(t *testing.T, m *Memberlist, expected int) {
 
 		if m.NumMembers() != expected {
 			failf("%s expected to have %d members but had: %v", m.config.Name, expected, m.Members())
+		}
+	})
+}
+
+// waitUntilSizeAndEstimate waits for both NumMembers and estNumNodes to reach expected value
+// Use this when you need to verify both metrics converge (e.g., after successful joins)
+func waitUntilSizeAndEstimate(t *testing.T, m *Memberlist, expected int) {
+	t.Helper()
+	retry(t, 15, 500*time.Millisecond, func(failf func(string, ...any)) {
+		t.Helper()
+
+		if m.NumMembers() != expected {
+			failf("%s expected to have %d members but had: %v", m.config.Name, expected, m.Members())
+		}
+		if m.estNumNodes() != expected {
+			failf("%s expected to have %d estimated nodes but had: %d", m.config.Name, expected, m.estNumNodes())
 		}
 	})
 }

--- a/net.go
+++ b/net.go
@@ -849,10 +849,10 @@ func (m *Memberlist) rawSendMsgPacket(a Address, node *Node, msg []byte) error {
 		}
 		m.nodeLock.RLock()
 		nodeState, ok := m.nodeMap[toAddr]
-		m.nodeLock.RUnlock()
 		if ok {
 			node = &nodeState.Node
 		}
+		m.nodeLock.RUnlock()
 	}
 
 	// Add a CRC to the end of the payload if the recipient understands

--- a/state_test.go
+++ b/state_test.go
@@ -2480,10 +2480,11 @@ func TestMemberlist_PushPull(t *testing.T) {
 	m1.aliveNode(&a2, nil, false)
 
 	// Gossip should send all this to m2. It's UDP though so retry a few times
-	retry(t, 5, 10*time.Millisecond, func(failf func(string, ...any)) {
+	retry(t, 10, 50*time.Millisecond, func(failf func(string, ...any)) {
 		m1.pushPull()
 
-		time.Sleep(3 * time.Millisecond)
+		// Wait longer for metrics to be emitted after pushPull completes
+		time.Sleep(20 * time.Millisecond)
 
 		if len(ch) < 2 {
 			failf("expected 2 messages from pushPull")


### PR DESCRIPTION
Address various issues with test reliability.
* A number of the tests assumed that the cluster state diverged immediately, whereas we need to poll for it to settle.
* Ensure that port bindings for tests don't collide with ports in use on the host.
* Wait a little longer for push-pull metrics to be emitted.
* Fix some broken Make targets

Ref: https://hashicorp.atlassian.net/browse/NMD-1557

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->