### PR TITLE
fix probe selection for very small clusters

### DIFF
--- a/state.go
+++ b/state.go
@@ -846,14 +846,8 @@ func (m *Memberlist) setProbeChannels(seqNo uint32, ackCh chan ackMessage, nackC
 		}
 	}
 
-	// Add the handlers
-	ah := &ackHandler{ackFn, nackFn, nil}
-	m.ackLock.Lock()
-	m.ackHandlers[seqNo] = ah
-	m.ackLock.Unlock()
-
-	// Setup a reaping routing
-	ah.timer = time.AfterFunc(timeout, func() {
+	// Add the handler, with a reaping routine
+	ah := &ackHandler{ackFn, nackFn, time.AfterFunc(timeout, func() {
 		m.ackLock.Lock()
 		delete(m.ackHandlers, seqNo)
 		m.ackLock.Unlock()
@@ -861,7 +855,11 @@ func (m *Memberlist) setProbeChannels(seqNo uint32, ackCh chan ackMessage, nackC
 		case ackCh <- ackMessage{false, nil, time.Now()}:
 		default:
 		}
-	})
+	})}
+
+	m.ackLock.Lock()
+	m.ackHandlers[seqNo] = ah
+	m.ackLock.Unlock()
 }
 
 // setAckHandler is used to attach a handler to be invoked when an ack with a

--- a/state_test.go
+++ b/state_test.go
@@ -28,7 +28,7 @@ func HostMemberlist(host string, t *testing.T, f func(*Config)) *Memberlist {
 	c.Name = host
 	c.BindAddr = host
 	c.BindPort = 0 // choose a free port
-	c.Logger = log.New(os.Stderr, host, log.LstdFlags)
+	c.Logger = log.New(os.Stderr, host+" ", log.LstdFlags)
 	if f != nil {
 		f(c)
 	}
@@ -818,11 +818,11 @@ func TestMemberList_ProbeNode_Awareness_MissedNack(t *testing.T) {
 		c.ProbeInterval = 200 * time.Millisecond
 		probeTimeMax = c.ProbeInterval + 50*time.Millisecond
 	})
-	defer func() {
+	t.Cleanup(func() {
 		if err := m1.Shutdown(); err != nil {
 			t.Fatal(err)
 		}
-	}()
+	})
 
 	bindPort := m1.config.BindPort
 
@@ -831,11 +831,11 @@ func TestMemberList_ProbeNode_Awareness_MissedNack(t *testing.T) {
 		c.ProbeTimeout = 10 * time.Millisecond
 		c.ProbeInterval = 200 * time.Millisecond
 	})
-	defer func() {
+	t.Cleanup(func() {
 		if err := m2.Shutdown(); err != nil {
 			t.Fatal(err)
 		}
-	}()
+	})
 
 	a1 := alive{Node: addr1.String(), Addr: ip1, Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
 	m1.aliveNode(&a1, nil, true)
@@ -850,11 +850,9 @@ func TestMemberList_ProbeNode_Awareness_MissedNack(t *testing.T) {
 	m1.aliveNode(&a4, nil, false)
 
 	// Make sure health looks good.
-	if score := m1.GetHealthScore(); score != 0 {
-		t.Fatalf("bad: %d", score)
-	}
+	require.Equal(t, 0, m1.GetHealthScore())
 
-	// Have node m1 probe m4.
+	// Have node m1 probe m4, which isn't up
 	n := m1.nodeMap[addr4.String()]
 	startProbe := time.Now()
 	m1.probeNode(n)
@@ -863,9 +861,7 @@ func TestMemberList_ProbeNode_Awareness_MissedNack(t *testing.T) {
 	// Node should be reported suspect.
 
 	m1.nodeLock.Lock()
-	if n.State != StateSuspect {
-		t.Fatalf("expect node to be suspect")
-	}
+	require.Equal(t, StateSuspect, n.State, "expect node to be suspect")
 	m1.nodeLock.Unlock()
 
 	// Make sure we timed out approximately on time.

--- a/util.go
+++ b/util.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"math/rand"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -130,16 +131,31 @@ func moveDeadNodes(nodes []*nodeState, gossipToTheDeadTime time.Duration) int {
 func kRandomNodes(k int, nodes []*nodeState, exclude func(*nodeState) bool) []Node {
 	n := len(nodes)
 	kNodes := make([]Node, 0, k)
+
+	// When n is very small (ex. 3-5 node Raft clusters), we can easily miss
+	// non-excluded nodes with random selection, so instead shuffle the slice
+	// to ensure the search is exhaustive
+	if n < k*3 {
+		nodes := slices.Clone(nodes)
+		shuffleNodes(nodes)
+		for idx := 0; idx < n && len(kNodes) < k; idx++ {
+			state := nodes[idx]
+			if exclude != nil && exclude(state) {
+				continue
+			}
+			kNodes = append(kNodes, state.Node)
+		}
+		return kNodes
+	}
+
 OUTER:
-	// Probe up to 3*n times, with large n this is not necessary
-	// since k << n, but with small n we want search to be
-	// exhaustive
+	// Probe up to 3*n times, with large n this is not necessary since k << n,
+	// but when n >= k*3 but still not "large", we want to give the search a shot
+	// at being exhaustive
 	for i := 0; i < 3*n && len(kNodes) < k; i++ {
-		// Get random nodeState
 		idx := randomOffset(n)
 		state := nodes[idx]
 
-		// Give the filter a shot at it.
 		if exclude != nil && exclude(state) {
 			continue OUTER
 		}
@@ -151,7 +167,6 @@ OUTER:
 			}
 		}
 
-		// Append the node
 		kNodes = append(kNodes, state.Node)
 	}
 	return kNodes

--- a/util_test.go
+++ b/util_test.go
@@ -294,6 +294,18 @@ func TestKRandomNodes(t *testing.T) {
 			}
 		}
 	}
+
+	// make sure we test the very-small path
+	nodes = nodes[:8]
+	s4 := kRandomNodes(3, nodes, filterFunc)
+	if len(s4) != 2 {
+		t.Fatalf("expected 2 nodes")
+	}
+	for _, n := range s4 {
+		if n.Name != "test3" && n.Name != "test6" {
+			t.Fatalf("unexpected node picked")
+		}
+	}
 }
 
 func TestMakeCompoundMessage(t *testing.T) {


### PR DESCRIPTION
When a node marks a peer as suspect, it measures its own health awareness by probing a subset of random nodes. The selection of k random nodes is via random offsets into the slice, but if n is very close to k and enough nodes are excluded by the filter function, it's possible to miss a node that we should be probing.

This scenario will be common in 3 node clusters as we commonly see with Nomad. If we're hitting this code path only 1 node will be non-excluded, so we expect to miss probing it ~2.6% of the time. This can result in false-negatives in health scoring, and also results in flaky tests of the lifeguard extension feature.

Add a new path for very small clusters that shuffles a copy of the nodes slice and iterates over it until we have k nodes or have exhausted the slice. Although this costs a bit extra for the shuffle, it also cuts the number of filter function calls from up to 3n to n, and eliminates the de-duplication check that iterates over the inprogress `kNodes` slice up to 3n times.

Also fixes a data race when setting up ack handlers, which was detected during testing. We shouldn't mutate the handler outside of the lock.

### How Has This Been Tested?

In addition to the test changes, I've run this with `go test -timeout=30m -count=100 -race . -run  TestMemberList_ProbeNode_Awareness` without failures.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->