### PR TITLE
limit remote state header values

### DIFF
--- a/net.go
+++ b/net.go
@@ -86,7 +86,8 @@ const (
 	userMsgOverhead        = 1
 	blockingWarning        = 10 * time.Millisecond // Warn if a UDP packet takes this long to process
 	maxPushStateBytes      = 20 * 1024 * 1024
-	maxPushPullRequests    = 128 // Maximum number of concurrent push/pull requests
+	maxPushStateNodes      = 1024 * 1024 // Each requires conservatively  ~20 bytes when encoded
+	maxPushPullRequests    = 128         // Maximum number of concurrent push/pull requests
 )
 
 // ping request sent directly to node
@@ -1233,6 +1234,10 @@ func (m *Memberlist) readRemoteState(bufConn io.Reader, dec *codec.Decoder) (boo
 		return false, nil, nil, err
 	}
 
+	if header.Nodes < 0 || header.Nodes > maxPushStateNodes {
+		return false, nil, nil, fmt.Errorf("number of nodes in header (%d) exceeds limit", header.Nodes)
+	}
+
 	// Allocate space for the transfer
 	remoteNodes := make([]pushNodeState, header.Nodes)
 
@@ -1241,6 +1246,10 @@ func (m *Memberlist) readRemoteState(bufConn io.Reader, dec *codec.Decoder) (boo
 		if err := dec.Decode(&remoteNodes[i]); err != nil {
 			return false, nil, nil, err
 		}
+	}
+
+	if header.UserStateLen < 0 || header.UserStateLen > maxPushStateBytes {
+		return false, nil, nil, fmt.Errorf("user state length (%d) exceeds limit", header.UserStateLen)
 	}
 
 	// Read the remote user state into a buffer

--- a/net_test.go
+++ b/net_test.go
@@ -1017,6 +1017,63 @@ func TestHandleCommand(t *testing.T) {
 	require.Contains(t, buf.String(), "missing message type byte")
 }
 
+func TestReadRemoteState_Limits(t *testing.T) {
+
+	mockNet := &MockNetwork{}
+	tr := mockNet.NewTransport("node")
+	logs := &bytes.Buffer{}
+	logger := log.New(logs, "", 0)
+
+	m := GetMemberlist(t, func(c *Config) {
+		c.EnableCompression = false
+		c.Logger = logger
+		c.Transport = tr
+		c.BindAddr = "127.0.0.1"
+		c.BindPort = 1
+	})
+	t.Cleanup(func() { _ = m.Shutdown() })
+
+	addr := joinHostPort(m.config.BindAddr, uint16(m.config.BindPort))
+
+	t.Run("nodes", func(t *testing.T) {
+		msg := pushPullHeader{Nodes: 10_000_000, UserStateLen: 100, Join: false}
+		buf, err := encode(pushPullMsg, msg, m.config.MsgpackUseNewTimeFormat)
+		require.NoError(t, err)
+
+		conn, err := tr.DialTimeout(addr, time.Millisecond*100)
+		require.NoError(t, err)
+
+		err = m.rawSendMsgStream(conn, buf.Bytes(), "")
+		require.NoError(t, err)
+
+		// conn closed: get nothing back
+		var out []byte
+		_, err = conn.Read(out)
+		require.Error(t, err, "EOF")
+		require.Contains(t, logs.String(),
+			"number of nodes in header (10000000) exceeds limit")
+	})
+
+	t.Run("user_state", func(t *testing.T) {
+		msg := pushPullHeader{Nodes: 0, UserStateLen: 30_000_000, Join: false}
+		buf, err := encode(pushPullMsg, msg, m.config.MsgpackUseNewTimeFormat)
+		require.NoError(t, err)
+
+		conn, err := tr.DialTimeout(addr, time.Millisecond*100)
+		require.NoError(t, err)
+
+		err = m.rawSendMsgStream(conn, buf.Bytes(), "")
+		require.NoError(t, err)
+
+		// conn closed: get nothing back
+		var out []byte
+		_, err = conn.Read(out)
+		require.Error(t, err, "EOF")
+		require.Contains(t, logs.String(),
+			"user state length (30000000) exceeds limit")
+	})
+}
+
 func TestHandleConn_NilConnAfterRemoveLabelHeaderFromStream(t *testing.T) {
 	mockNet := &MockNetwork{}
 


### PR DESCRIPTION
The header of a push-pull state message contains a count of nodes and user state length. As an optimization, both of these fields are used to pre-allocate memory to receive the remote state before copying it off the wire. But if the header mismatches the actual state, a very small pull-push state message (or at least one below the message size limit) can be used to consume excess memory on the receiver.

Limit the memory allocated such that the maximum amount allocated cannot exceed the maximum actual size of the push-pull state, either in number of nodes or size of the user state.

Ref: https://hashicorp.atlassian.net/browse/SECVULN-42161
Ref: https://hashicorp.atlassian.net/browse/NMD-1523

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
