### PR TITLE
limit user message length

### DIFF
--- a/net.go
+++ b/net.go
@@ -86,8 +86,9 @@ const (
 	userMsgOverhead        = 1
 	blockingWarning        = 10 * time.Millisecond // Warn if a UDP packet takes this long to process
 	maxPushStateBytes      = 20 * 1024 * 1024
-	maxPushStateNodes      = 1024 * 1024 // Each requires conservatively  ~20 bytes when encoded
-	maxPushPullRequests    = 128         // Maximum number of concurrent push/pull requests
+	maxPushStateNodes      = 1024 * 1024      // Each requires conservatively  ~20 bytes when encoded
+	maxUserMsgBytes        = 20 * 1024 * 1024 // Largest user message we will buffer off the wire
+	maxPushPullRequests    = 128              // Maximum number of concurrent push/pull requests
 )
 
 // ping request sent directly to node
@@ -1323,6 +1324,10 @@ func (m *Memberlist) readUserMsg(bufConn io.Reader, dec *codec.Decoder) error {
 	var header userMsgHeader
 	if err := dec.Decode(&header); err != nil {
 		return err
+	}
+
+	if header.UserMsgLen < 0 || header.UserMsgLen > maxUserMsgBytes {
+		return fmt.Errorf("user message length (%d) exceeds limit", header.UserMsgLen)
 	}
 
 	// Read the user message into a buffer

--- a/net_test.go
+++ b/net_test.go
@@ -1074,6 +1074,42 @@ func TestReadRemoteState_Limits(t *testing.T) {
 	})
 }
 
+func TestReadUserMsg_Limit(t *testing.T) {
+
+	mockNet := &MockNetwork{}
+	tr := mockNet.NewTransport("node")
+	logs := &bytes.Buffer{}
+	logger := log.New(logs, "", 0)
+
+	m := GetMemberlist(t, func(c *Config) {
+		c.EnableCompression = false
+		c.Logger = logger
+		c.Transport = tr
+		c.BindAddr = "127.0.0.1"
+		c.BindPort = 1
+	})
+	t.Cleanup(func() { _ = m.Shutdown() })
+
+	addr := joinHostPort(m.config.BindAddr, uint16(m.config.BindPort))
+
+	msg := userMsgHeader{UserMsgLen: 30_000_000}
+	buf, err := encode(userMsg, msg, m.config.MsgpackUseNewTimeFormat)
+	require.NoError(t, err)
+
+	conn, err := tr.DialTimeout(addr, time.Millisecond*100)
+	require.NoError(t, err)
+
+	err = m.rawSendMsgStream(conn, buf.Bytes(), "")
+	require.NoError(t, err)
+
+	// conn closed: get nothing back
+	var out []byte
+	_, err = conn.Read(out)
+	require.ErrorContains(t, err, "EOF")
+	require.Contains(t, logs.String(),
+		"user message length (30000000) exceeds limit")
+}
+
 func TestHandleConn_NilConnAfterRemoveLabelHeaderFromStream(t *testing.T) {
 	mockNet := &MockNetwork{}
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

readUserMsg sizes make([]byte, header.UserMsgLen) from the wire header with no bound, so a small userMsg frame declaring a large length forces a large allocation on the receiver. This is the userMsg path of the same issue #357 fixed for push-pull state.

## Related Issue

Fixes #360 

## How Has This Been Tested?

Full go test ./... passes
