### PR TITLE
limit decompressed message size

### DIFF
--- a/net.go
+++ b/net.go
@@ -89,6 +89,8 @@ const (
 	maxPushStateNodes      = 1024 * 1024      // Each requires conservatively  ~20 bytes when encoded
 	maxUserMsgBytes        = 20 * 1024 * 1024 // Largest user message we will buffer off the wire
 	maxPushPullRequests    = 128              // Maximum number of concurrent push/pull requests
+
+	maxDecompressedBytes = 2 * maxPushStateBytes // Largest push/pull we will decompress: user state plus an equal node budget
 )
 
 // ping request sent directly to node

--- a/util.go
+++ b/util.go
@@ -302,11 +302,14 @@ func decompressBuffer(c *compress) ([]byte, error) {
 		_ = uncomp.Close()
 	}()
 
-	// Read all the data
+	// Ensure a compressMsg can't decompress to too much data.
 	var b bytes.Buffer
-	_, err := io.Copy(&b, uncomp)
-	if err != nil {
+	n, err := io.CopyN(&b, uncomp, maxDecompressedBytes+1)
+	if err != nil && err != io.EOF {
 		return nil, err
+	}
+	if n > maxDecompressedBytes {
+		return nil, fmt.Errorf("decompressed message is larger than limit (%d)", maxDecompressedBytes)
 	}
 
 	// Return the uncompressed bytes

--- a/util_test.go
+++ b/util_test.go
@@ -399,3 +399,19 @@ func TestCompressDecompressPayload(t *testing.T) {
 		t.Fatalf("bad payload: %v", decomp)
 	}
 }
+
+func TestDecompressPayload_Limit(t *testing.T) {
+	// Over the limit: rejected.
+	buf, err := compressPayload(make([]byte, maxDecompressedBytes+1), false)
+	require.NoError(t, err)
+
+	_, err = decompressPayload(buf.Bytes()[1:])
+	require.ErrorContains(t, err, "larger than limit")
+
+	// Between the wire limit and the decompressed limit: accepted.
+	buf, err = compressPayload(make([]byte, maxPushStateBytes+1), false)
+	require.NoError(t, err)
+
+	_, err = decompressPayload(buf.Bytes()[1:])
+	require.NoError(t, err)
+}


### PR DESCRIPTION

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

decompressBuffer drains the LZW reader with io.Copy into an unbounded buffer, so a small compressMsg expands without limit and can exhaust memory. Cap the output at maxDecompressedBytes with io.CopyN and error past it.

## Related Issue

Fixes #362 

## How Has This Been Tested?

Full go test ./... passes
