### PR TITLE
CI: fix test target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SHELL := /bin/bash
 
 # test runs the test suite
 test: subnet
-	go test -count ./...
+	go test -count=1 ./...
 
 # runs integration tests
 integ: subnet


### PR DESCRIPTION
The `make test` target is missing the argument to `-count`, which causes it to fail.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->