### PR TITLE
docs: clarify SendBestEffort does not enforce UDPBufferSize

### DIFF
--- a/memberlist.go
+++ b/memberlist.go
@@ -581,8 +581,12 @@ func (m *Memberlist) SendToTCP(to *Node, msg []byte) error {
 
 // SendBestEffort uses the unreliable packet-oriented interface of the transport
 // to target a user message at the given node (this does not use the gossip
-// mechanism). The maximum size of the message depends on the configured
-// UDPBufferSize for this memberlist instance.
+// mechanism).
+//
+// Unlike gossip/sendMsg filling, SendBestEffort does not enforce Config.UDPBufferSize
+// as a maximum payload size; oversized messages may still be written and can fail
+// at the transport or OS UDP layer. Prefer SendReliable for large messages.
+// UDPBufferSize is used when packing piggybacked gossip into UDP packets.
 func (m *Memberlist) SendBestEffort(to *Node, msg []byte) error {
 	// Encode as a user message
 	buf := make([]byte, 1, len(msg)+1)


### PR DESCRIPTION
## Description

`SendBestEffort` docs said the max message size depends on `Config.UDPBufferSize`. That is not enforced on this path.

Call chain: `SendBestEffort` → `rawSendMsgPacket` → transport `WriteToAddress` — no `UDPBufferSize` check.

`UDPBufferSize` is used when packing piggybacked gossip (`sendMsg` / `gossip` via `getBroadcast`).

## Fix

Document actual behavior:

- no hard max from `UDPBufferSize` on `SendBestEffort`
- oversized messages may fail at transport/OS UDP layer
- use `SendReliable` for large messages
- `UDPBufferSize` still matters for gossip packing

## Tests

Docs-only. `go test -c` compiles.

## Linked Issue

Closes #348
