### PR TITLE
fix panic in Vsn deference

### DIFF
--- a/net.go
+++ b/net.go
@@ -1291,6 +1291,10 @@ func (m *Memberlist) mergeRemoteState(join bool, remoteNodes []pushNodeState, us
 	if join && m.config.Merge != nil {
 		nodes := make([]*Node, len(remoteNodes))
 		for idx, n := range remoteNodes {
+			// Skip nodes without proper version information
+			if len(n.Vsn) < 6 {
+				continue
+			}
 			nodes[idx] = &Node{
 				Name:  n.Name,
 				Addr:  n.Addr,

--- a/net.go
+++ b/net.go
@@ -1291,23 +1291,22 @@ func (m *Memberlist) mergeRemoteState(join bool, remoteNodes []pushNodeState, us
 	if join && m.config.Merge != nil {
 		nodes := make([]*Node, len(remoteNodes))
 		for idx, n := range remoteNodes {
-			// Skip nodes without proper version information
-			if len(n.Vsn) < 6 {
-				continue
-			}
-			nodes[idx] = &Node{
+			node := &Node{
 				Name:  n.Name,
 				Addr:  n.Addr,
 				Port:  n.Port,
 				Meta:  n.Meta,
 				State: n.State,
-				PMin:  n.Vsn[0],
-				PMax:  n.Vsn[1],
-				PCur:  n.Vsn[2],
-				DMin:  n.Vsn[3],
-				DMax:  n.Vsn[4],
-				DCur:  n.Vsn[5],
 			}
+			if len(n.Vsn) >= 6 {
+				node.PMin = n.Vsn[0]
+				node.PMax = n.Vsn[1]
+				node.PCur = n.Vsn[2]
+				node.DMin = n.Vsn[3]
+				node.DMax = n.Vsn[4]
+				node.DCur = n.Vsn[5]
+			}
+			nodes[idx] = node
 		}
 		if err := m.config.Merge.NotifyMerge(nodes); err != nil {
 			return err

--- a/state.go
+++ b/state.go
@@ -712,9 +712,8 @@ func (m *Memberlist) verifyProtocol(remote []pushNodeState) error {
 			continue
 		}
 
-		// Skip nodes that don't have versions set, it just means
-		// their version is zero.
-		if len(rn.Vsn) == 0 {
+		// Skip nodes that don't have proper version info
+		if len(rn.Vsn) < 5 {
 			continue
 		}
 
@@ -763,7 +762,7 @@ func (m *Memberlist) verifyProtocol(remote []pushNodeState) error {
 	// node in the cluster satisifies this.
 	for _, n := range remote {
 		var nPCur, nDCur uint8
-		if len(n.Vsn) > 0 {
+		if len(n.Vsn) >= 6 {
 			nPCur = n.Vsn[2]
 			nDCur = n.Vsn[5]
 		}
@@ -1117,7 +1116,7 @@ func (m *Memberlist) aliveNode(a *alive, notify chan struct{}, bootstrap bool) {
 		m.encodeBroadcastNotify(a.Node, aliveMsg, a, notify)
 
 		// Update protocol versions if it arrived
-		if len(a.Vsn) > 0 {
+		if len(a.Vsn) >= 6 {
 			state.PMin = a.Vsn[0]
 			state.PMax = a.Vsn[1]
 			state.PCur = a.Vsn[2]


### PR DESCRIPTION
The protocol version array is not length-checked everywhere, which can result in a panic if we deference a Vsn off the wire that's short.

Ref: https://hashicorp.atlassian.net/browse/PSA-2897
Ref: https://hashicorp.atlassian.net/browse/NMD-1624

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
