### PR TITLE
check length of decompressed buffer before indexing

### DIFF
--- a/net.go
+++ b/net.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -1216,7 +1217,7 @@ func (m *Memberlist) readStream(conn net.Conn, streamLabel string) (messageType,
 			return 0, nil, nil, err
 		}
 		if len(decomp) == 0 {
-			return 0, nil, nil, fmt.Errorf("decompressed message is empty")
+			return 0, nil, nil, errors.New("decompressed message is empty")
 		}
 
 		// Reset the message type

--- a/net.go
+++ b/net.go
@@ -1215,6 +1215,9 @@ func (m *Memberlist) readStream(conn net.Conn, streamLabel string) (messageType,
 		if err != nil {
 			return 0, nil, nil, err
 		}
+		if len(decomp) == 0 {
+			return 0, nil, nil, fmt.Errorf("decompressed message is empty")
+		}
 
 		// Reset the message type
 		msgType = messageType(decomp[0])


### PR DESCRIPTION
If a compressed message is empty after decompression, the `readStream` method will attempt to index into it and panic. Do a length check here and treat such malformed messages as an error.

Ref: https://hashicorp.atlassian.net/browse/PSA-2897
Ref: https://hashicorp.atlassian.net/browse/NMD-1624

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
